### PR TITLE
Refine decompiled expressions via new simplification passes

### DIFF
--- a/Vibe/Decompiler.cs
+++ b/Vibe/Decompiler.cs
@@ -106,6 +106,9 @@ public sealed class Decompiler
         }
 
         Transformations.SimplifyRedundantAssign(fn);
+        Transformations.SimplifyArithmeticIdentities(fn);
+        Transformations.SimplifyBooleanTernary(fn);
+        Transformations.SimplifyLogicalNots(fn);
 
         // Pretty print IR
         var pp = new IR.PrettyPrinter(new IR.PrettyPrinter.Options


### PR DESCRIPTION
## Summary
- Add `SimplifyArithmeticIdentities` to collapse operations with neutral elements
- Add `SimplifyBooleanTernary` and `SimplifyLogicalNots` for cleaner boolean logic
- Invoke new passes from decompiler pipeline

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68c104b06f248320b4e10f8c4d6748d4