### PR TITLE
feat: add LLM-based refinement of decompiled output

### DIFF
--- a/Vibe/LlmRefiner.cs
+++ b/Vibe/LlmRefiner.cs
@@ -1,0 +1,88 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+public interface ILlmProvider
+{
+    Task<string> RefineAsync(string decompiledCode, CancellationToken cancellationToken = default);
+}
+
+public sealed class OpenAiLlmProvider : ILlmProvider
+{
+    private readonly HttpClient _http = new();
+    public string ApiKey { get; }
+    public string Model { get; }
+
+    public OpenAiLlmProvider(string apiKey, string model = "gpt-4o-mini")
+    {
+        ApiKey = apiKey;
+        Model = model;
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+    }
+
+    public async Task<string> RefineAsync(string decompiledCode, CancellationToken cancellationToken = default)
+    {
+        var req = new
+        {
+            model = Model,
+            messages = new object[]
+            {
+                new { role = "system", content = "You rewrite decompiled machine code into clear and idiomatic C code." },
+                new { role = "user", content = $"Rewrite the following decompiler output into readable C code, approximating the original source.\n\n{decompiledCode}" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(req);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var resp = await _http.PostAsync("https://api.openai.com/v1/chat/completions", content, cancellationToken);
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(cancellationToken));
+        var message = doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString();
+        return message?.Trim() ?? string.Empty;
+    }
+}
+
+public sealed class AnthropicLlmProvider : ILlmProvider
+{
+    private readonly HttpClient _http = new();
+    public string ApiKey { get; }
+    public string Model { get; }
+
+    public AnthropicLlmProvider(string apiKey, string model = "claude-3-5-sonnet-20240620")
+    {
+        ApiKey = apiKey;
+        Model = model;
+        _http.DefaultRequestHeaders.Add("x-api-key", ApiKey);
+        _http.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
+    }
+
+    public async Task<string> RefineAsync(string decompiledCode, CancellationToken cancellationToken = default)
+    {
+        var req = new
+        {
+            model = Model,
+            max_tokens = 1024,
+            system = "You rewrite decompiled machine code into clear and idiomatic C code.",
+            messages = new object[]
+            {
+                new { role = "user", content = $"Rewrite the following decompiler output into readable C code, approximating the original source.\n\n{decompiledCode}" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(req);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var resp = await _http.PostAsync("https://api.anthropic.com/v1/messages", content, cancellationToken);
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(cancellationToken));
+        var message = doc.RootElement.GetProperty("content")[0].GetProperty("text").GetString();
+        return message?.Trim() ?? string.Empty;
+    }
+}
+
+public static class LlmRefiner
+{
+    public static Task<string> RefineAsync(string decompiledCode, ILlmProvider provider, CancellationToken cancellationToken = default)
+        => provider.RefineAsync(decompiledCode, cancellationToken);
+}
+

--- a/Vibe/Program.cs
+++ b/Vibe/Program.cs
@@ -2,10 +2,27 @@
 
 public static class Program
 {
-    static void Main(string[] args)
+    static async Task Main(string[] args)
     {
         var disasm = DisassembleExportToPseudo("C:\\Windows\\System32\\Microsoft-Edge-WebView\\msedge.dll", "CreateTestWebClientProxy", 256 * 1024);
         Console.WriteLine(disasm);
+
+        ILlmProvider? provider = null;
+        string? openAiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        string? anthropicKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+
+        if (!string.IsNullOrWhiteSpace(openAiKey))
+            provider = new OpenAiLlmProvider(openAiKey);
+        else if (!string.IsNullOrWhiteSpace(anthropicKey))
+            provider = new AnthropicLlmProvider(anthropicKey);
+
+        if (provider is not null)
+        {
+            string refined = await provider.RefineAsync(disasm);
+            Console.WriteLine();
+            Console.WriteLine("// ---- Refined by LLM ----");
+            Console.WriteLine(refined);
+        }
     }
     /// <summary>
     /// Disassembles a Windows exported function (default: ntdll!RtlGetVersion) into C-like pseudocode


### PR DESCRIPTION
## Summary
- add OpenAI and Anthropic LLM providers with a common interface
- hook decompiler output to optional LLM refinement when API key is present

## Testing
- `dotnet build -bl` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package dotnet-sdk-9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c17c91f4188320b20967f0ad229a74