### PR TITLE
Add regex-based export decompilation overload

### DIFF
--- a/Vibe/PEReaderLite.cs
+++ b/Vibe/PEReaderLite.cs
@@ -143,6 +143,26 @@ public sealed class PEReaderLite
         throw new EntryPointNotFoundException($"Export '{name}' not found in module.");
     }
 
+    public IEnumerable<string> EnumerateExportNames()
+    {
+        if (ExportRva == 0 || ExportSize == 0)
+            yield break;
+
+        int expDirOff = RvaToOffsetChecked(ExportRva);
+
+        uint NumberOfNames = U32(expDirOff + 0x18);
+        uint AddressOfNames = U32(expDirOff + 0x20);
+
+        int namesOff = RvaToOffsetChecked(AddressOfNames);
+
+        for (uint i = 0; i < NumberOfNames; i++)
+        {
+            uint nameRva = U32(namesOff + (int)(i * 4));
+            int nameOff = RvaToOffsetChecked(nameRva);
+            yield return ReadAsciiZ(nameOff);
+        }
+    }
+
     // ------------------ local data helpers ------------------
 
     private ushort U16(int off) =>

--- a/Vibe/Program.cs
+++ b/Vibe/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.RegularExpressions;
 
 public static class Program
 {
@@ -125,5 +126,43 @@ public static class Program
 
             return (dll, sym);
         }
+    }
+
+    public static Dictionary<string, string> DisassembleExportsToPseudo(
+        string dllName,
+        string exportNamePattern,
+        int maxBytes = 4096)
+    {
+        // Resolve a *64-bit* System32 path even if this process is 32-bit (WOW64).
+        string ResolveSystemDllPath(string name)
+        {
+            if (!name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                name += ".dll";
+
+            string windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+            string dir = (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+                ? Path.Combine(windows, "Sysnative") // 32-bit process reaching 64-bit System32
+                : Path.Combine(windows, "System32");
+
+            string path = Path.Combine(dir, name);
+            if (!File.Exists(path))
+                throw new FileNotFoundException($"System DLL not found: {path}");
+            return path;
+        }
+
+        string dllPath = ResolveSystemDllPath(dllName);
+        var regex = new Regex(exportNamePattern);
+        var pe = new PEReaderLite(dllPath);
+        var results = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var name in pe.EnumerateExportNames())
+        {
+            if (regex.IsMatch(name))
+            {
+                results[name] = DisassembleExportToPseudo(dllName, name, maxBytes);
+            }
+        }
+
+        return results;
     }
 }

--- a/Vibe/README.md
+++ b/Vibe/README.md
@@ -275,6 +275,10 @@ public static string DisassembleExportToPseudo(
     string dllName,     // e.g., "ntdll.dll"
     string exportName,  // e.g., "RtlGetVersion"
     int maxBytes = 4096)
+public static Dictionary<string,string> DisassembleExportsToPseudo(
+    string dllName,           // e.g., "ntdll.dll",
+    string exportNamePattern, // regex, e.g., "^Rtl.*"
+    int maxBytes = 4096)
 ```
 
 Steps:
@@ -318,7 +322,7 @@ Key Heuristics
 Usage Patterns & Extensibility
 ------------------------------
 
-*   **As a library**: Call `Program.DisassembleExportToPseudo()` from your code.  
+*   **As a library**: Call `Program.DisassembleExportToPseudo()` for a single export or `Program.DisassembleExportsToPseudo()` with a regex pattern string to process all matching exports.
     Or skip `Program` and use `PEReader` + `Decompiler` directly if you already have bytes.
 *   **Change the function under test**: In `Program.Main`, edit the DLL/export name and the `maxBytes` bound. The decompiler will stop at first `RET` anyway.
 *   **Constant naming**:


### PR DESCRIPTION
## Summary
- rename regex-based export decompilation method to `DisassembleExportsToPseudo`
- accept a regex pattern string and construct the `Regex` internally
- document new string-based API usage

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c17a7890a4832083ce5368297c254c