### PR TITLE
Add Win32DocFetcher with timeout and User-Agent

### DIFF
--- a/Vibe/Win32DocFetcher.cs
+++ b/Vibe/Win32DocFetcher.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+public static class Win32DocFetcher
+{
+    private static readonly HttpClient _http = new HttpClient
+    {
+        Timeout = TimeSpan.FromSeconds(30)
+    };
+
+    static Win32DocFetcher()
+    {
+        _http.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue("Vibe-Decompiler", "1.0"));
+    }
+
+    /// <summary>
+    /// Attempts to download HTML documentation for a given Windows API export.
+    /// Uses the learn.microsoft.com search API to locate a documentation page.
+    /// </summary>
+    /// <param name="dllName">Name of the DLL that exports the function (optional filter).</param>
+    /// <param name="exportName">Exported function name (e.g. "CreateFileW").</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The HTML string if found; otherwise <c>null</c>.</returns>
+    public static async Task<string?> TryDownloadExportDocAsync(
+        string dllName,
+        string exportName,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(exportName))
+            throw new ArgumentException("Export name must be provided", nameof(exportName));
+
+        string query = exportName;
+        if (!string.IsNullOrWhiteSpace(dllName))
+            query = dllName + " " + exportName;
+
+        string url = "https://learn.microsoft.com/api/search" +
+                     "?" +
+                     "search=" + Uri.EscapeDataString(query) +
+                     "&scope=desktop&locale=en-us";
+
+        try
+        {
+            using var stream = await _http.GetStreamAsync(url, cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            if (!doc.RootElement.TryGetProperty("results", out var results))
+                return null;
+
+            string exportLower = exportName.ToLowerInvariant();
+            foreach (var result in results.EnumerateArray())
+            {
+                if (!result.TryGetProperty("url", out var urlProp))
+                    continue;
+                string resultUrl = urlProp.GetString() ?? string.Empty;
+                if (!resultUrl.Contains("learn.microsoft.com"))
+                    continue;
+                // Basic heuristic: ensure the URL contains the export name in lowercase.
+                if (!resultUrl.ToLowerInvariant().Contains(exportLower))
+                    continue;
+
+                try
+                {
+                    return await _http.GetStringAsync(resultUrl, cancellationToken);
+                }
+                catch (HttpRequestException)
+                {
+                    // Skip and try next result.
+                }
+                catch (TaskCanceledException)
+                {
+                    // Skip and try next result.
+                }
+            }
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+        catch (TaskCanceledException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+}
+

--- a/Vibe/Win32DocFetcher.cs
+++ b/Vibe/Win32DocFetcher.cs
@@ -38,10 +38,13 @@ public static class Win32DocFetcher
         if (!string.IsNullOrWhiteSpace(dllName))
             query = dllName + " " + exportName;
 
-        string url = "https://learn.microsoft.com/api/search" +
-                     "?" +
-                     "search=" + Uri.EscapeDataString(query) +
-                     "&scope=desktop&locale=en-us";
+        var uriBuilder = new UriBuilder("https://learn.microsoft.com/api/search");
+        var queryParams = System.Web.HttpUtility.ParseQueryString(string.Empty);
+        queryParams["search"] = query;
+        queryParams["scope"] = "desktop";
+        queryParams["locale"] = "en-us";
+        uriBuilder.Query = queryParams.ToString();
+        string url = uriBuilder.ToString();
 
         try
         {


### PR DESCRIPTION
## Summary
- add Win32DocFetcher to retrieve Windows API documentation using Microsoft Learn search API
- configure HttpClient with 30s timeout and custom User-Agent
- handle task cancellations and HTTP errors gracefully

## Testing
- `dotnet build -c Release` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c18229cafc8320b91ed72b231b9a4d