### PR TITLE
Add safety checks and defaults to PEReaderLite

### DIFF
--- a/Vibe/PEReaderLite.cs
+++ b/Vibe/PEReaderLite.cs
@@ -5,8 +5,13 @@ public sealed class PEReaderLite
     public readonly byte[] Data;
     public readonly ulong ImageBase;
     public readonly List<Section> Sections = new();
+    public readonly DataDirectory[] DataDirectories;
     public readonly uint ExportRva;
     public readonly uint ExportSize;
+    public readonly uint CliHeaderRva;
+    public readonly uint CliHeaderSize;
+    public bool HasDotNetMetadata => CliHeaderRva != 0;
+    public readonly List<ImportModule> Imports = new();
     public readonly uint SizeOfHeaders; // NEW: keep SizeOfHeaders for header-range RVA mapping
 
     public PEReaderLite(string path)
@@ -40,8 +45,33 @@ public sealed class PEReaderLite
         if (numberOfRvaAndSizes < 1)
             throw new BadImageFormatException("No data directories.");
 
-        ExportRva = U32(dataDirOff + 0 * 8 + 0);
-        ExportSize = U32(dataDirOff + 0 * 8 + 4);
+        int dirCount = (int)Math.Min(numberOfRvaAndSizes, 16);
+
+        // Ensure we don't read beyond the optional header bounds
+        int maxDirCount = (optHeaderSize - 112) / 8;
+        dirCount = Math.Min(dirCount, maxDirCount);
+
+        DataDirectories = new DataDirectory[dirCount];
+        for (int i = 0; i < dirCount; i++)
+        {
+            uint rva = U32(dataDirOff + i * 8 + 0);
+            uint size = U32(dataDirOff + i * 8 + 4);
+            DataDirectories[i] = new DataDirectory { VirtualAddress = rva, Size = size };
+        }
+
+        if (dirCount > 0)
+        {
+            ExportRva = DataDirectories[0].VirtualAddress;
+            ExportSize = DataDirectories[0].Size;
+        }
+
+        uint importRva = dirCount > 1 ? DataDirectories[1].VirtualAddress : 0;
+
+        if (dirCount > 14)
+        {
+            CliHeaderRva = DataDirectories[14].VirtualAddress;
+            CliHeaderSize = DataDirectories[14].Size;
+        }
 
         // Sections
         int secOff = optOff + optHeaderSize;
@@ -63,6 +93,9 @@ public sealed class PEReaderLite
                 PointerToRawData = ptrToRawData
             });
         }
+
+        if (importRva != 0)
+            ParseImports(importRva);
     }
 
     public Section? GetSectionForRva(uint rva)
@@ -143,6 +176,74 @@ public sealed class PEReaderLite
         throw new EntryPointNotFoundException($"Export '{name}' not found in module.");
     }
 
+    private void ParseImports(uint importRva)
+    {
+        int descOff = RvaToOffsetChecked(importRva);
+        int descCount = 0;
+        while (true)
+        {
+            if (descCount++ >= 1000)
+                throw new BadImageFormatException("Too many import descriptors.");
+
+            uint originalFirstThunk = U32(descOff + 0);
+            uint timeDateStamp = U32(descOff + 4);
+            uint forwarderChain = U32(descOff + 8);
+            uint nameRva = U32(descOff + 12);
+            uint firstThunk = U32(descOff + 16);
+
+            if (originalFirstThunk == 0 && timeDateStamp == 0 &&
+                forwarderChain == 0 && nameRva == 0 && firstThunk == 0)
+                break;
+
+            if (nameRva == 0)
+            {
+                descOff += 20;
+                continue; // Skip malformed import descriptor
+            }
+
+            string moduleName = ReadAsciiZ(RvaToOffsetChecked(nameRva));
+            uint thunkRva = originalFirstThunk != 0 ? originalFirstThunk : firstThunk;
+
+            if (thunkRva == 0)
+            {
+                descOff += 20;
+                continue; // Skip import descriptor with no thunks
+            }
+
+            int thunkOff = RvaToOffsetChecked(thunkRva);
+
+            var module = new ImportModule { Name = moduleName };
+
+            while (true)
+            {
+                ulong entry = U64(thunkOff);
+                if (entry == 0)
+                    break;
+
+                bool byOrdinal = (entry & 0x8000000000000000UL) != 0;
+                if (byOrdinal)
+                {
+                    ushort ord = (ushort)(entry & 0xFFFF);
+                    module.Symbols.Add(ImportSymbol.FromOrdinal(ord));
+                }
+                else
+                {
+                    uint hintNameRva = (uint)entry;
+                    int hnOff = RvaToOffsetChecked(hintNameRva);
+                    if (hnOff + 2 >= Data.Length)
+                        break;
+                    string funcName = ReadAsciiZ(hnOff + 2); // skip hint
+                    module.Symbols.Add(ImportSymbol.FromName(funcName));
+                }
+
+                thunkOff += 8;
+            }
+
+            Imports.Add(module);
+            descOff += 20;
+        }
+    }
+
     // ------------------ local data helpers ------------------
 
     private ushort U16(int off) =>
@@ -172,6 +273,12 @@ public sealed class PEReaderLite
         return Encoding.ASCII.GetString(Data, off, i - off);
     }
 
+    public readonly struct DataDirectory
+    {
+        public uint VirtualAddress { get; init; }
+        public uint Size { get; init; }
+    }
+
     public readonly struct Section
     {
         public string Name { get; init; }
@@ -179,6 +286,28 @@ public sealed class PEReaderLite
         public uint VirtualSize { get; init; }
         public uint SizeOfRawData { get; init; }
         public uint PointerToRawData { get; init; }
+    }
+
+    public sealed class ImportModule
+    {
+        public string Name { get; init; } = string.Empty;
+        public List<ImportSymbol> Symbols { get; } = new();
+    }
+
+    public readonly struct ImportSymbol
+    {
+        public string? Name { get; }
+        public ushort Ordinal { get; }
+        public bool IsOrdinal => Name == null;
+
+        private ImportSymbol(string? name, ushort ord)
+        {
+            Name = name;
+            Ordinal = ord;
+        }
+
+        public static ImportSymbol FromName(string name) => new(name, 0);
+        public static ImportSymbol FromOrdinal(ushort ord) => new(null, ord);
     }
 
     public readonly struct ExportInfo

--- a/Vibe/PEReaderLite.cs
+++ b/Vibe/PEReaderLite.cs
@@ -185,6 +185,10 @@ public sealed class PEReaderLite
             if (descCount++ >= 1000)
                 throw new BadImageFormatException("Too many import descriptors.");
 
+            // Check bounds before reading import descriptor (20 bytes)
+            if (descOff + 20 > Data.Length)
+                break;
+
             uint originalFirstThunk = U32(descOff + 0);
             uint timeDateStamp = U32(descOff + 4);
             uint forwarderChain = U32(descOff + 8);

--- a/Vibe/README.md
+++ b/Vibe/README.md
@@ -244,12 +244,13 @@ public interface IConstantNameProvider {
 
 ### PEReader (minimal PE32+ reader)
 
-File: **[`PEReader.cs`](PEReader.cs)**
+File: **[`PEReaderLite.cs`](PEReaderLite.cs)**
 
 A tiny **read‑only** PE32+ parser that’s “just enough” for this tool:
 
 *   Validates `"MZ"` and `"PE\0\0"`, checks PE32+ magic.
-*   Parses sections and the **export directory**.
+*   Parses sections, the **export** directory, and the **import** table.
+*   Flags managed images by detecting the .NET metadata directory (CLI header) but does not parse it.
 *   `FindExport(name)`:
     *   Scans export name table to find RVA for the symbol,
     *   Detects **forwarders** (RVAs that point inside the export table) → returns forwarder string (`"DLL.Symbol"`).


### PR DESCRIPTION
## Summary
- guard optional header directory parsing with header size bounds
- validate import descriptors for null RVAs and limit descriptor iteration
- default import module names and check hint strings to avoid out-of-range reads

## Testing
- `~/.dotnet/dotnet build Vibe.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c18259d98883209ac2e821ba8f70c6