### PR TITLE
refactor: improve LLM provider disposal and error handling

### DIFF
--- a/Vibe/Program.cs
+++ b/Vibe/Program.cs
@@ -18,10 +18,21 @@ public static class Program
 
         if (provider is not null)
         {
-            string refined = await provider.RefineAsync(disasm);
-            Console.WriteLine();
-            Console.WriteLine("// ---- Refined by LLM ----");
-            Console.WriteLine(refined);
+            using (provider)
+            {
+                try
+                {
+                    string refined = await provider.RefineAsync(disasm);
+                    Console.WriteLine();
+                    Console.WriteLine("// ---- Refined by LLM ----");
+                    Console.WriteLine(refined);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine($"// ---- LLM refinement failed: {ex.Message} ----");
+                }
+            }
         }
     }
     /// <summary>

--- a/Vibe/Vibe.csproj
+++ b/Vibe/Vibe.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Vibe</RootNamespace>


### PR DESCRIPTION
## Summary
- dispose HttpClient instances and validate responses for LLM providers
- add configurable options and higher token limits for Anthropic provider
- handle LLM failures gracefully and target .NET 8.0

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68c18469c2a883209f9e8dc49215fdf2