### PR TITLE
Search Windows Win32 metadata automatically

### DIFF
--- a/Vibe/Program.cs
+++ b/Vibe/Program.cs
@@ -182,7 +182,19 @@ public static class Program
 
             foreach (var cache in GetNuGetCacheDirectories())
             {
-                if (!Directory.Exists(cache)) continue;
+            if (!Directory.Exists(cache)) continue;
+            
+            // First try extracted packages (more common in global packages folder)
+            foreach (var packageDir in Directory.EnumerateDirectories(cache, "microsoft.windows.sdk.win32metadata*", SearchOption.TopDirectoryOnly))
+            {
+                foreach (var winmdFile in Directory.EnumerateFiles(packageDir, "Windows.Win32.winmd", SearchOption.AllDirectories))
+                {
+                    db.LoadWin32MetadataFromWinmd(winmdFile);
+                    return;
+                }
+            }
+            
+            // Fallback to .nupkg files (for HTTP cache locations)
                 foreach (var nupkg in Directory.EnumerateFiles(cache, "Microsoft.Windows.SDK.Win32Metadata*.nupkg", SearchOption.AllDirectories))
                 {
                     try

--- a/Vibe/README.md
+++ b/Vibe/README.md
@@ -65,7 +65,7 @@ Console.WriteLine(disasm);
 So running the built exe prints pseudocode for **`dbghelp!MakeSureDirectoryPathExists`**. Example output is included at the end of this README (truncated here).
 
 > **Note on constants (Win32 enums):**  
-> `Program.cs` loads Win32 metadata from a local `.winmd` file so that return values can be printed as names (e.g., `STATUS_*`). Update the path in `Program.cs` to wherever your **Windows.Win32.winmd** lives, or comment out the constant-mapping lines if you don’t need it.
+> `Program.cs` tries to load Win32 metadata (`Windows.Win32.winmd`) to print return values as symbolic names (e.g., `STATUS_*`). It first searches the repo and standard NuGet caches for any `Microsoft.Windows.SDK.Win32Metadata` package, using the metadata if found. If no `.winmd` is located, decompilation still proceeds but constants remain numeric.
 
 * * *
 


### PR DESCRIPTION
## Summary
- Search repository and NuGet caches for `Windows.Win32.winmd`
- Extract metadata from `Microsoft.Windows.SDK.Win32Metadata` packages when found
- Document automatic constant metadata loading

## Testing
- ⚠️ `dotnet build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18989876c832084375a8ba6b8f8b7