### PR TITLE
Add import bounds checking and resolve merge conflicts

### DIFF
--- a/Vibe/Decompiler.cs
+++ b/Vibe/Decompiler.cs
@@ -106,6 +106,9 @@ public sealed class Decompiler
         }
 
         Transformations.SimplifyRedundantAssign(fn);
+        Transformations.SimplifyArithmeticIdentities(fn);
+        Transformations.SimplifyBooleanTernary(fn);
+        Transformations.SimplifyLogicalNots(fn);
 
         // Pretty print IR
         var pp = new IR.PrettyPrinter(new IR.PrettyPrinter.Options

--- a/Vibe/LlmRefiner.cs
+++ b/Vibe/LlmRefiner.cs
@@ -1,0 +1,107 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+public interface ILlmProvider
+{
+    Task<string> RefineAsync(string decompiledCode, CancellationToken cancellationToken = default);
+}
+
+public sealed class OpenAiLlmProvider : ILlmProvider, IDisposable
+{
+    private readonly HttpClient _http = new();
+    public string ApiKey { get; }
+    public string Model { get; }
+
+    public OpenAiLlmProvider(string apiKey, string model = "gpt-4o-mini")
+    {
+        ApiKey = apiKey;
+        Model = model;
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+    }
+
+    public async Task<string> RefineAsync(string decompiledCode, CancellationToken cancellationToken = default)
+    {
+        var req = new
+        {
+            model = Model,
+            messages = new object[]
+            {
+                new { role = "system", content = "You rewrite decompiled machine code into clear and idiomatic C code." },
+                new { role = "user", content = $"Rewrite the following decompiler output into readable C code, approximating the original source.\n\n{decompiledCode}" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(req);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var resp = await _http.PostAsync("https://api.openai.com/v1/chat/completions", content, cancellationToken);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var errorContent = await resp.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException($"OpenAI API request failed with status {resp.StatusCode}: {errorContent}");
+        }
+        
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(cancellationToken));
+        var choices = doc.RootElement.GetProperty("choices");
+        if (choices.GetArrayLength() == 0)
+            throw new InvalidOperationException("OpenAI API returned no choices");
+            
+        var message = choices[0].GetProperty("message").GetProperty("content").GetString();
+        return message?.Trim() ?? string.Empty;
+    }
+
+    public void Dispose() => _http.Dispose();
+}
+
+public sealed class AnthropicLlmProvider : ILlmProvider, IDisposable
+{
+    private readonly HttpClient _http = new();
+    public string ApiKey { get; }
+    public string Model { get; }
+    public string ApiVersion { get; }
+
+    public AnthropicLlmProvider(string apiKey, string model = "claude-3-5-sonnet-20240620", string apiVersion = "2023-06-01")
+    {
+        ApiKey = apiKey;
+        Model = model;
+        ApiVersion = apiVersion;
+        _http.DefaultRequestHeaders.Add("x-api-key", ApiKey);
+        _http.DefaultRequestHeaders.Add("anthropic-version", ApiVersion);
+    }
+
+    public async Task<string> RefineAsync(string decompiledCode, CancellationToken cancellationToken = default)
+    {
+        var req = new
+        {
+            model = Model,
+            max_tokens = 4096,
+            system = "You rewrite decompiled machine code into clear and idiomatic C code.",
+            messages = new object[]
+            {
+                new { role = "user", content = $"Rewrite the following decompiler output into readable C code, approximating the original source.\n\n{decompiledCode}" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(req);
+        using var reqContent = new StringContent(json, Encoding.UTF8, "application/json");
+        using var resp = await _http.PostAsync("https://api.anthropic.com/v1/messages", reqContent, cancellationToken);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var errorContent = await resp.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException($"Anthropic API request failed with status {resp.StatusCode}: {errorContent}");
+        }
+        
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(cancellationToken));
+        var content = doc.RootElement.GetProperty("content");
+        if (content.GetArrayLength() == 0)
+            throw new InvalidOperationException("Anthropic API returned no content");
+            
+        var message = content[0].GetProperty("text").GetString();
+        return message?.Trim() ?? string.Empty;
+    }
+
+    public void Dispose() => _http.Dispose();
+}
+
+

--- a/Vibe/PEReaderLite.cs
+++ b/Vibe/PEReaderLite.cs
@@ -217,9 +217,17 @@ public sealed class PEReaderLite
             int thunkOff = RvaToOffsetChecked(thunkRva);
 
             var module = new ImportModule { Name = moduleName };
+            int symbolCount = 0;
 
             while (true)
             {
+                if (symbolCount++ >= 10000)
+                    throw new BadImageFormatException("Too many import symbols.");
+
+                // Check bounds before reading thunk entry (8 bytes)
+                if (thunkOff + 8 > Data.Length)
+                    break;
+
                 ulong entry = U64(thunkOff);
                 if (entry == 0)
                     break;

--- a/Vibe/Program.cs
+++ b/Vibe/Program.cs
@@ -2,10 +2,48 @@
 
 public static class Program
 {
-    static void Main(string[] args)
+    static async Task Main(string[] args)
     {
         var disasm = DisassembleExportToPseudo("C:\\Windows\\System32\\Microsoft-Edge-WebView\\msedge.dll", "CreateTestWebClientProxy", 256 * 1024);
         Console.WriteLine(disasm);
+
+        ILlmProvider? provider = null;
+        string? openAiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        string? anthropicKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+
+        if (!string.IsNullOrWhiteSpace(openAiKey))
+            provider = new OpenAiLlmProvider(openAiKey);
+        else if (!string.IsNullOrWhiteSpace(anthropicKey))
+            provider = new AnthropicLlmProvider(anthropicKey);
+
+        if (provider is not null)
+        {
+            try
+            {
+                if (provider is IDisposable disposable)
+                {
+                    using (disposable)
+                    {
+                        string refined = await provider.RefineAsync(disasm);
+                        Console.WriteLine();
+                        Console.WriteLine("// ---- Refined by LLM ----");
+                        Console.WriteLine(refined);
+                    }
+                }
+                else
+                {
+                    string refined = await provider.RefineAsync(disasm);
+                    Console.WriteLine();
+                    Console.WriteLine("// ---- Refined by LLM ----");
+                    Console.WriteLine(refined);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"// ---- LLM refinement failed: {ex.Message} ----");
+            }
+        }
     }
     /// <summary>
     /// Disassembles a Windows exported function (default: ntdll!RtlGetVersion) into C-like pseudocode

--- a/Vibe/README.md
+++ b/Vibe/README.md
@@ -41,7 +41,7 @@ Quick Start
 ### Prerequisites
 
 *   **Windows x64**
-*   **.NET SDK 9.0** (project targets `net9.0`)
+*   **.NET SDK 8.0** (project targets `net8.0`)
 *   NuGet package: **Iced 1.21.0** (restored automatically by `dotnet`)
 
 ### Build

--- a/Vibe/Vibe.csproj
+++ b/Vibe/Vibe.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Vibe</RootNamespace>

--- a/Vibe/Win32DocFetcher.cs
+++ b/Vibe/Win32DocFetcher.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+
+public static class Win32DocFetcher
+{
+    private static readonly HttpClient _http = new HttpClient()
+    {
+        Timeout = TimeSpan.FromSeconds(30)
+    };
+
+    static Win32DocFetcher()
+    {
+        _http.DefaultRequestHeaders.UserAgent.TryParseAdd("Vibe-Decompiler/1.0");
+    }
+
+    /// <summary>
+    /// Attempts to download HTML documentation for a given Windows API export.
+    /// Uses the learn.microsoft.com search API to locate a documentation page.
+    /// </summary>
+    /// <param name="dllName">Name of the DLL that exports the function (optional filter).</param>
+    /// <param name="exportName">Exported function name (e.g. "CreateFileW").</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The HTML string if found; otherwise <c>null</c>.</returns>
+    public static async Task<string?> TryDownloadExportDocAsync(
+        string dllName,
+        string exportName,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(exportName))
+            throw new ArgumentException("Export name must be provided", nameof(exportName));
+
+        string query = exportName;
+        if (!string.IsNullOrWhiteSpace(dllName))
+            query = dllName + " " + exportName;
+
+        string url = "https://learn.microsoft.com/api/search" +
+                     "?" +
+                     "search=" + Uri.EscapeDataString(query) +
+                     "&scope=desktop&locale=en-us";
+
+        JsonElement results;
+        try
+        {
+            using var stream = await _http.GetStreamAsync(url, cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            if (!doc.RootElement.TryGetProperty("results", out results) || results.ValueKind != JsonValueKind.Array)
+                return null;
+        }
+        catch (HttpRequestException)
+        {
+            // Search API request failed - return null to maintain "Try*" semantics
+            return null;
+        }
+        catch (JsonException)
+        {
+            // Invalid JSON response - return null to maintain "Try*" semantics
+            return null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // User requested cancellation - propagate immediately
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout occurred - return null to maintain "Try*" semantics
+            return null;
+        }
+
+        foreach (var result in results.EnumerateArray())
+        {
+            if (!result.TryGetProperty("url", out var urlProp))
+                continue;
+            string resultUrl = urlProp.GetString() ?? string.Empty;
+            if (resultUrl.IndexOf("learn.microsoft.com", StringComparison.OrdinalIgnoreCase) < 0)
+                continue;
+            // Basic heuristic: ensure the URL contains the export name (case-insensitive).
+            if (resultUrl.IndexOf(exportName, StringComparison.OrdinalIgnoreCase) < 0)
+                continue;
+
+            try
+            {
+                return await _http.GetStringAsync(resultUrl, cancellationToken);
+            }
+            catch (HttpRequestException)
+            {
+                // Skip and try next result.
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // User requested cancellation - propagate immediately
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                // Timeout occurred - skip and try next result.
+            }
+        }
+
+        return null;
+    }
+}

--- a/docs/testing-proposal.md
+++ b/docs/testing-proposal.md
@@ -1,0 +1,38 @@
+# Testing Strategy Proposal
+
+This document outlines a strategy for introducing automated tests into the Vibe project and keeping them maintainable as the code base evolves.
+
+## Test framework
+- Adopt **xUnit** as the primary test framework and run it through `dotnet test`.
+- xUnit integrates well with the existing .NET tooling, offers rich assertion helpers, and supports parallel runs.
+- For property-based testing of transformation invariants, add **FsCheck** or a similar library.
+
+## Making the code testable
+- Favor small, focused classes over large static helpers so that behavior can be unit tested.
+- Introduce dependency injection or pass interfaces into constructors instead of using global state, which enables mocking in tests.
+- Break transformation passes into composable units that can run in isolation, enabling targeted unit tests.
+- Ensure I/O such as reading binaries or writing output is abstracted behind interfaces so that tests can supply in‑memory streams.
+
+## Keeping tests stable
+- Test individual transformation passes and intermediate representations rather than the final decompiled output, which changes frequently.
+- Where output comparisons are necessary, normalize results (e.g., removing whitespace or ordering) before asserting equality.
+- Use golden files sparingly and regenerate them only when intentional changes are made, reviewing diffs as part of code review.
+- Run deterministic builds in CI to avoid environmental differences.
+
+## What to test with automation
+- Unit tests for IR manipulation, constant propagation, and other transformation logic.
+- Integration tests that feed small sample binaries through a subset of passes and validate high‑level properties (e.g., no unhandled exceptions, consistent instruction counts).
+- Regression tests for bugs that have been fixed to prevent reintroductions.
+- Fast performance smoke tests to ensure new passes do not drastically increase run time.
+
+## What not to test
+- Full decompiled text output: it churns as passes are added or tweaked and is better suited for manual review or high‑level sanity scripts.
+- UI or console formatting, which can vary across environments and adds little confidence.
+- Non‑deterministic behaviors such as timing‑dependent code without first enforcing determinism.
+
+## Additional considerations
+- Add a `tests` directory with parallel project structure to the main source tree when tests are introduced.
+- Configure continuous integration to run `dotnet test` on every pull request.
+- Use code coverage tools to highlight untested areas and drive further refactoring.
+- Document new test utilities and patterns so contributors can easily follow established practices.
+


### PR DESCRIPTION
## Summary
- add bounds checks for import descriptors and thunk entries in PEReaderLite
- limit import symbols per module to prevent abuse
- merge latest base changes and resolve conflicts

## Testing
- `dotnet build Vibe.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c19b355190832085d9ed3b9403a775