### PR TITLE
Add minimal WPF DLL export decompiler

### DIFF
--- a/Vibe.Gui/App.xaml
+++ b/Vibe.Gui/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="Vibe.Gui.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/Vibe.Gui/App.xaml.cs
+++ b/Vibe.Gui/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace Vibe.Gui;
+
+public partial class App : Application
+{
+}

--- a/Vibe.Gui/MainWindow.xaml
+++ b/Vibe.Gui/MainWindow.xaml
@@ -1,0 +1,30 @@
+<Window x:Class="Vibe.Gui.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Vibe Decompiler" Height="450" Width="800" Background="#FFFFFF">
+    <Window.Resources>
+        <SolidColorBrush x:Key="AccentBrush" Color="#C6DC1D" />
+        <SolidColorBrush x:Key="PanelBrush" Color="#EEEEEE" />
+        <SolidColorBrush x:Key="TextBrush" Color="#2D4D78" />
+    </Window.Resources>
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="_Open..." Click="OpenDll_Click" />
+                <Separator />
+                <MenuItem Header="E_xit" Click="Exit_Click" />
+            </MenuItem>
+        </Menu>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="200" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0" Background="{StaticResource PanelBrush}">
+                <ListBox x:Name="ExportList" Margin="4" />
+                <Button x:Name="DecompileButton" Content="Decompile" Margin="4" Background="{StaticResource AccentBrush}" Click="DecompileButton_Click" />
+            </StackPanel>
+            <TextBox x:Name="OutputBox" Grid.Column="1" Margin="4" FontFamily="Consolas" AcceptsReturn="True" AcceptsTab="True" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" TextWrapping="NoWrap" Foreground="{StaticResource TextBrush}" Background="#FFFFFF" />
+        </Grid>
+    </DockPanel>
+</Window>

--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Windows;
+using Microsoft.Win32;
+using Vibe.Decompiler;
+
+namespace Vibe.Gui;
+
+public partial class MainWindow : Window
+{
+    private PEReaderLite? _pe;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void OpenDll_Click(object sender, RoutedEventArgs e)
+    {
+        var dlg = new OpenFileDialog { Filter = "DLL files (*.dll)|*.dll|All files (*.*)|*.*" };
+        if (dlg.ShowDialog() == true)
+        {
+            try
+            {
+                _pe = new PEReaderLite(dlg.FileName);
+                var names = _pe.EnumerateExportNames().OrderBy(n => n).ToList();
+                ExportList.ItemsSource = names;
+                OutputBox.Clear();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+    }
+
+    private void DecompileButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_pe == null)
+            return;
+        if (ExportList.SelectedItem is not string name)
+            return;
+        try
+        {
+            var exp = _pe.FindExport(name);
+            if (exp.IsForwarder)
+            {
+                OutputBox.Text = $"{name} -> {exp.ForwarderString}";
+                return;
+            }
+
+            int off = _pe.RvaToOffsetChecked(exp.FunctionRva);
+            int maxLen = Math.Min(4096, _pe.Data.Length - off);
+            var bytes = new byte[maxLen];
+            Array.Copy(_pe.Data, off, bytes, 0, maxLen);
+            var engine = new Engine();
+            var code = engine.ToPseudoCode(bytes, new Engine.Options
+            {
+                BaseAddress = _pe.ImageBase + exp.FunctionRva,
+                FunctionName = name
+            });
+            OutputBox.Text = code;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private void Exit_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}

--- a/Vibe.Gui/Vibe.Gui.csproj
+++ b/Vibe.Gui/Vibe.Gui.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Vibe.Decompiler\Vibe.Decompiler.csproj" />
+  </ItemGroup>
+</Project>

--- a/Vibe.sln
+++ b/Vibe.sln
@@ -23,12 +23,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{91C8EFF0-9
 		docs\transformations-architecture.md = docs\transformations-architecture.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vibe.Gui", "Vibe.Gui\Vibe.Gui.csproj", "{1440EBD9-4E12-4327-9C11-12BF6F95D060}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {1440EBD9-4E12-4327-9C11-12BF6F95D060}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1440EBD9-4E12-4327-9C11-12BF6F95D060}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1440EBD9-4E12-4327-9C11-12BF6F95D060}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1440EBD9-4E12-4327-9C11-12BF6F95D060}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4F5F7FF1-14D5-4132-A5B8-62A2C9B82668}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F5F7FF1-14D5-4132-A5B8-62A2C9B82668}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F5F7FF1-14D5-4132-A5B8-62A2C9B82668}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
## Summary
- Add `Vibe.Gui` WPF project referencing `Vibe.Decompiler`
- Provide UI to open unmanaged DLLs, list exports, and decompile selections

## Testing
- `dotnet build Vibe.sln -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e244c0508320806c40307fba886a