### PR TITLE
Send docs to LLM during refinement

### DIFF
--- a/Vibe.Decompiler/Program.cs
+++ b/Vibe.Decompiler/Program.cs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT-0
 
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Compression;
 using System.Text;
 
@@ -9,17 +11,41 @@ public static class Program
 {
     static async Task Main(string[] args)
     {
-        var disasm = DisassembleExportToPseudo("C:\\Windows\\System32\\Microsoft-Edge-WebView\\msedge.dll", "CreateTestWebClientProxy", 256 * 1024);
+        string dllPath = "C:\\Windows\\System32\\Microsoft-Edge-WebView\\msedge.dll";
+        string exportName = "CreateTestWebClientProxy";
+
+        var disasm = DisassembleExportToPseudo(dllPath, exportName, 256 * 1024);
         Console.WriteLine(disasm);
+
+        var docs = new List<string>();
+
+        try
+        {
+            string? msDoc = await Win32DocFetcher.TryDownloadExportDocAsync(Path.GetFileName(dllPath), exportName);
+            if (msDoc is not null)
+                docs.Add(msDoc);
+        }
+        catch { }
 
         ILlmProvider? provider = null;
         string? openAiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
         string? anthropicKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
 
         if (!string.IsNullOrWhiteSpace(openAiKey))
+        {
             provider = new OpenAiLlmProvider(openAiKey);
+            try
+            {
+                using var evaluator = new OpenAiDocPageEvaluator(openAiKey);
+                var pages = await DuckDuckGoDocFetcher.FindDocumentationPagesAsync(exportName, 2, evaluator);
+                docs.AddRange(pages);
+            }
+            catch { }
+        }
         else if (!string.IsNullOrWhiteSpace(anthropicKey))
+        {
             provider = new AnthropicLlmProvider(anthropicKey);
+        }
 
         if (provider is not null)
         {
@@ -29,7 +55,7 @@ public static class Program
                 {
                     using (disposable)
                     {
-                        string refined = await provider.RefineAsync(disasm);
+                        string refined = await provider.RefineAsync(disasm, docs);
                         Console.WriteLine();
                         Console.WriteLine("// ---- Refined by LLM ----");
                         Console.WriteLine(refined);
@@ -37,7 +63,7 @@ public static class Program
                 }
                 else
                 {
-                    string refined = await provider.RefineAsync(disasm);
+                    string refined = await provider.RefineAsync(disasm, docs);
                     Console.WriteLine();
                     Console.WriteLine("// ---- Refined by LLM ----");
                     Console.WriteLine(refined);


### PR DESCRIPTION
## Summary
- pipe Win32 and DuckDuckGo documentation into LLM refinement
- extend ILlmProvider to accept documentation snippets
- include fetched docs in refinement requests for OpenAI and Anthropic

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68c1e55af2548320bbeb60721b32870b