### PR TITLE
Fix ObjectDisposedException in Win32DocFetcher

### DIFF
--- a/Vibe.Decompiler/Win32DocFetcher.cs
+++ b/Vibe.Decompiler/Win32DocFetcher.cs
@@ -49,8 +49,11 @@ public static class Win32DocFetcher
         {
             await using var stream = await _http.GetStreamAsync(url, cancellationToken);
             using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
-            if (!doc.RootElement.TryGetProperty("results", out results) || results.ValueKind != JsonValueKind.Array)
+            if (!doc.RootElement.TryGetProperty("results", out var resultsElement) || resultsElement.ValueKind != JsonValueKind.Array)
                 return null;
+
+            // Clone the results array so it survives after the JsonDocument is disposed
+            results = resultsElement.Clone();
         }
         catch (HttpRequestException)
         {


### PR DESCRIPTION
## Summary
- Clone search results array before disposing `JsonDocument` to avoid ObjectDisposedException

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" for Vibe.Gui)*
- `dotnet build Vibe.Decompiler/Vibe.Decompiler.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c1ed0a906883209c95acad429a9d25