### PR TITLE
refactor: add SimplifyArithmeticPass

### DIFF
--- a/Vibe.Decompiler.Tests/Transformations/SimplifyArithmeticPassTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/SimplifyArithmeticPassTests.cs
@@ -1,0 +1,59 @@
+using Vibe.Decompiler.Transformations;
+using Xunit;
+
+namespace Vibe.Decompiler.Tests.Transformations;
+
+public class SimplifyArithmeticPassTests
+{
+    [Fact]
+    public void SimplifiesAdditionWithZero()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rdx"),
+            new IR.BinOpExpr(IR.BinOp.Add, new IR.RegExpr("rax"), new IR.Const(0, 64))));
+        fn.Blocks.Add(bb);
+
+        var pass = new SimplifyArithmeticPass();
+        pass.Run(fn);
+
+        var stmt = Assert.IsType<IR.AssignStmt>(fn.Blocks[0].Statements[0]);
+        var rhs = Assert.IsType<IR.RegExpr>(stmt.Rhs);
+        Assert.Equal("rax", rhs.Name);
+    }
+
+    [Fact]
+    public void SimplifiesMultiplicationByOne()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rdx"),
+            new IR.BinOpExpr(IR.BinOp.Mul, new IR.RegExpr("rax"), new IR.Const(1, 64))));
+        fn.Blocks.Add(bb);
+
+        var pass = new SimplifyArithmeticPass();
+        pass.Run(fn);
+
+        var stmt = Assert.IsType<IR.AssignStmt>(fn.Blocks[0].Statements[0]);
+        var rhs = Assert.IsType<IR.RegExpr>(stmt.Rhs);
+        Assert.Equal("rax", rhs.Name);
+    }
+
+    [Fact]
+    public void SimplifiesXorWithItselfToZero()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        var reg = new IR.RegExpr("rax");
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rdx"),
+            new IR.BinOpExpr(IR.BinOp.Xor, reg, reg)));
+        fn.Blocks.Add(bb);
+
+        var pass = new SimplifyArithmeticPass();
+        pass.Run(fn);
+
+        var stmt = Assert.IsType<IR.AssignStmt>(fn.Blocks[0].Statements[0]);
+        var zero = Assert.IsType<IR.Const>(stmt.Rhs);
+        Assert.Equal(0, zero.Value);
+    }
+}

--- a/Vibe.Decompiler/Transformations/DefaultPassPipeline.cs
+++ b/Vibe.Decompiler/Transformations/DefaultPassPipeline.cs
@@ -13,6 +13,7 @@ public static class DefaultPassPipeline
         return new PassManager(new ITransformationPass[]
         {
             new SimplifyRedundantAssignPass(),
+            new SimplifyArithmeticPass(),
         });
     }
 }

--- a/Vibe.Decompiler/Transformations/SimplifyArithmeticPass.cs
+++ b/Vibe.Decompiler/Transformations/SimplifyArithmeticPass.cs
@@ -71,7 +71,11 @@ public sealed class SimplifyArithmeticPass : IRRewriter, ITransformationPass
     {
         if (x is IR.Const c) return c.Value == -1;
         if (x is IR.UConst uc)
-            return uc.Bits >= 64 ? uc.Value == ulong.MaxValue : uc.Value == ((1UL << (int)uc.Bits) - 1);
+        {
+            if (uc.Bits >= 64) return uc.Value == ulong.MaxValue;
+            if (uc.Bits == 0) return false; // Edge case: avoid shift by 64
+            return uc.Value == ((1UL << (int)uc.Bits) - 1);
+        }
         return false;
     }
     private static bool ExpressionsEqual(IR.Expr a, IR.Expr b) => a.Equals(b);

--- a/Vibe.Decompiler/Transformations/SimplifyArithmeticPass.cs
+++ b/Vibe.Decompiler/Transformations/SimplifyArithmeticPass.cs
@@ -1,0 +1,89 @@
+namespace Vibe.Decompiler.Transformations;
+
+/// <summary>
+/// Simplifies arithmetic expressions by applying identity rules
+/// such as x + 0 => x or x * 1 => x.
+/// </summary>
+public sealed class SimplifyArithmeticPass : IRRewriter, ITransformationPass
+{
+    public void Run(IR.FunctionIR fn)
+    {
+        foreach (var bb in fn.Blocks)
+        {
+            for (int i = 0; i < bb.Statements.Count; i++)
+            {
+                bb.Statements[i] = RewriteStmt(bb.Statements[i]);
+            }
+        }
+    }
+
+    protected override IR.Expr RewriteBinOp(IR.BinOpExpr b)
+    {
+        var L = RewriteExpr(b.Left);
+        var R = RewriteExpr(b.Right);
+
+        switch (b.Op)
+        {
+            case IR.BinOp.Add:
+                if (IsZero(L)) return R;
+                if (IsZero(R)) return L;
+                break;
+            case IR.BinOp.Sub:
+                if (IsZero(R)) return L;
+                if (ExpressionsEqual(L, R)) return MakeZeroFrom(L, R);
+                break;
+            case IR.BinOp.Mul:
+                if (IsZero(L) || IsZero(R)) return MakeZeroFrom(L, R);
+                if (IsOne(L)) return R;
+                if (IsOne(R)) return L;
+                break;
+            case IR.BinOp.UDiv:
+            case IR.BinOp.SDiv:
+                if (IsOne(R)) return L;
+                break;
+            case IR.BinOp.And:
+                if (IsZero(L) || IsZero(R)) return MakeZeroFrom(L, R);
+                if (IsAllOnes(L)) return R;
+                if (IsAllOnes(R)) return L;
+                break;
+            case IR.BinOp.Or:
+                if (IsZero(L)) return R;
+                if (IsZero(R)) return L;
+                break;
+            case IR.BinOp.Xor:
+                if (IsZero(L)) return R;
+                if (IsZero(R)) return L;
+                if (ExpressionsEqual(L, R)) return MakeZeroFrom(L, R);
+                break;
+            case IR.BinOp.Shl:
+            case IR.BinOp.Shr:
+            case IR.BinOp.Sar:
+                if (IsZero(R)) return L;
+                break;
+        }
+
+        return new IR.BinOpExpr(b.Op, L, R);
+    }
+
+    private static bool IsZero(IR.Expr x) => x is IR.Const c && c.Value == 0 || x is IR.UConst uc && uc.Value == 0;
+    private static bool IsOne(IR.Expr x) => x is IR.Const c && c.Value == 1 || x is IR.UConst uc && uc.Value == 1;
+    private static bool IsAllOnes(IR.Expr x)
+    {
+        if (x is IR.Const c) return c.Value == -1;
+        if (x is IR.UConst uc)
+            return uc.Bits >= 64 ? uc.Value == ulong.MaxValue : uc.Value == ((1UL << (int)uc.Bits) - 1);
+        return false;
+    }
+    private static bool ExpressionsEqual(IR.Expr a, IR.Expr b) => a.Equals(b);
+    private static IR.Expr MakeZeroFrom(IR.Expr a, IR.Expr b)
+    {
+        int bits = GetBits(a) ?? GetBits(b) ?? 32;
+        return new IR.Const(0, bits);
+    }
+    private static int? GetBits(IR.Expr e) => e switch
+    {
+        IR.Const c => c.Bits,
+        IR.UConst uc => (int)uc.Bits,
+        _ => null,
+    };
+}

--- a/docs/transformations-architecture.md
+++ b/docs/transformations-architecture.md
@@ -178,10 +178,10 @@ public abstract class IRRewriter
 ## 7. Migration Checklist
 
  - [x] Create foundational files (`ITransformationPass`, `PassManager`, `IRRewriter`).
- - [x] Move `SimplifyRedundantAssign` into `SimplifyRedundantAssignPass`.
- - [x] Add unit tests for `SimplifyRedundantAssignPass`.
- - [ ] Move `SimplifyArithmeticIdentities` into `SimplifyArithmeticPass`.
- - [ ] Add unit tests for `SimplifyArithmeticPass`.
+- [x] Move `SimplifyRedundantAssign` into `SimplifyRedundantAssignPass`.
+- [x] Add unit tests for `SimplifyRedundantAssignPass`.
+ - [x] Move `SimplifyArithmeticIdentities` into `SimplifyArithmeticPass`.
+ - [x] Add unit tests for `SimplifyArithmeticPass`.
  - [ ] Move `FoldConstants` into `FoldConstantsPass`.
  - [ ] Add unit tests for `FoldConstantsPass`.
  - [ ] Repeat for remaining passes: `DeadCodeEliminationPass`, `CanonicalizeLoopsPass`, etc.


### PR DESCRIPTION
## Summary
- introduce `SimplifyArithmeticPass` for basic algebraic identities
- cover arithmetic identities with dedicated unit tests
- include new pass in default transformation pipeline
- update transformation refactor checklist

## Testing
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c204ab7f9483208cb35b70eb8eaa32