### PR TITLE
test: cover pass manager and pipeline

### DIFF
--- a/Vibe.Decompiler.Tests/Transformations/DefaultPassPipelineTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/DefaultPassPipelineTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Vibe.Decompiler.Transformations;
+using Xunit;
+
+namespace Vibe.Decompiler.Tests.Transformations;
+
+public class DefaultPassPipelineTests
+{
+    [Fact]
+    public void CreateIncludesSimplifyRedundantAssignPass()
+    {
+        var pm = DefaultPassPipeline.Create();
+        var field = typeof(PassManager).GetField("_passes", BindingFlags.NonPublic | BindingFlags.Instance);
+        var passes = Assert.IsType<List<ITransformationPass>>(field!.GetValue(pm));
+        Assert.Single(passes);
+        Assert.IsType<SimplifyRedundantAssignPass>(passes[0]);
+    }
+
+    [Fact]
+    public void PipelineTransformsFunction()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rax"), new IR.RegExpr("rax")));
+        fn.Blocks.Add(bb);
+
+        var pm = DefaultPassPipeline.Create();
+        pm.Run(fn);
+
+        Assert.IsType<IR.NopStmt>(fn.Blocks[0].Statements[0]);
+    }
+}

--- a/Vibe.Decompiler.Tests/Transformations/DefaultPassPipelineTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/DefaultPassPipelineTests.cs
@@ -22,18 +22,4 @@ public class DefaultPassPipelineTests
         // Verify that SimplifyRedundantAssignPass is included by checking its behavior
         Assert.IsType<IR.NopStmt>(fn.Blocks[0].Statements[0]);
     }
-
-    [Fact]
-    public void PipelineTransformsFunction()
-    {
-        var fn = new IR.FunctionIR("test");
-        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
-        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rax"), new IR.RegExpr("rax")));
-        fn.Blocks.Add(bb);
-
-        var pm = DefaultPassPipeline.Create();
-        pm.Run(fn);
-
-        Assert.IsType<IR.NopStmt>(fn.Blocks[0].Statements[0]);
-    }
 }

--- a/Vibe.Decompiler.Tests/Transformations/DefaultPassPipelineTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/DefaultPassPipelineTests.cs
@@ -11,10 +11,16 @@ public class DefaultPassPipelineTests
     public void CreateIncludesSimplifyRedundantAssignPass()
     {
         var pm = DefaultPassPipeline.Create();
-        var field = typeof(PassManager).GetField("_passes", BindingFlags.NonPublic | BindingFlags.Instance);
-        var passes = Assert.IsType<List<ITransformationPass>>(field!.GetValue(pm));
-        Assert.Single(passes);
-        Assert.IsType<SimplifyRedundantAssignPass>(passes[0]);
+        // Test behavior instead of implementation details
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rax"), new IR.RegExpr("rax")));
+        fn.Blocks.Add(bb);
+
+        pm.Run(fn);
+
+        // Verify that SimplifyRedundantAssignPass is included by checking its behavior
+        Assert.IsType<IR.NopStmt>(fn.Blocks[0].Statements[0]);
     }
 
     [Fact]

--- a/Vibe.Decompiler.Tests/Transformations/PassManagerTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/PassManagerTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Vibe.Decompiler.Transformations;
+using Xunit;
+
+namespace Vibe.Decompiler.Tests.Transformations;
+
+public class PassManagerTests
+{
+    private sealed class TrackingPass : ITransformationPass
+    {
+        private readonly int _id;
+        private readonly List<int> _order;
+        public TrackingPass(int id, List<int> order)
+        {
+            _id = id; _order = order;
+        }
+        public void Run(IR.FunctionIR fn) => _order.Add(_id);
+    }
+
+    [Fact]
+    public void RunsPassesInRegistrationOrder()
+    {
+        var fn = new IR.FunctionIR("test");
+        var order = new List<int>();
+        var pm = new PassManager();
+        pm.Add(new TrackingPass(1, order))
+          .Add(new TrackingPass(2, order));
+        pm.Run(fn);
+        Assert.Equal(new[] { 1, 2 }, order);
+    }
+
+    [Fact]
+    public void ConstructorAddsInitialPasses()
+    {
+        var fn = new IR.FunctionIR("test");
+        var order = new List<int>();
+        var pm = new PassManager(new ITransformationPass[]
+        {
+            new TrackingPass(1, order),
+            new TrackingPass(2, order)
+        });
+        pm.Run(fn);
+        Assert.Equal(new[] { 1, 2 }, order);
+    }
+}

--- a/Vibe.Decompiler.Tests/Transformations/SimplifyRedundantAssignPassTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/SimplifyRedundantAssignPassTests.cs
@@ -18,4 +18,37 @@ public class SimplifyRedundantAssignPassTests
 
         Assert.IsType<IR.NopStmt>(fn.Blocks[0].Statements[0]);
     }
+
+    [Fact]
+    public void LeavesNonSelfAssignmentsUnchanged()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        var assign = new IR.AssignStmt(new IR.RegExpr("rax"), new IR.RegExpr("rbx"));
+        bb.Statements.Add(assign);
+        fn.Blocks.Add(bb);
+
+        var pass = new SimplifyRedundantAssignPass();
+        pass.Run(fn);
+
+        var result = Assert.IsType<IR.AssignStmt>(fn.Blocks[0].Statements[0]);
+        Assert.Equal("rax", ((IR.RegExpr)result.Lhs).Name);
+        Assert.Equal("rbx", ((IR.RegExpr)result.Rhs).Name);
+    }
+
+    [Fact]
+    public void SimplifiesAllSelfAssignments()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rax"), new IR.RegExpr("rax")));
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rbx"), new IR.RegExpr("rbx")));
+        fn.Blocks.Add(bb);
+
+        var pass = new SimplifyRedundantAssignPass();
+        pass.Run(fn);
+
+        foreach (var stmt in fn.Blocks[0].Statements)
+            Assert.IsType<IR.NopStmt>(stmt);
+    }
 }


### PR DESCRIPTION
## Summary
- expand SimplifyRedundantAssignPass tests to cover more scenarios
- add PassManager tests for execution order and constructor
- verify default pipeline composition and behavior

## Testing
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`
- `dotnet test tests/Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c20697c36483208ec39ecc2429ebd1