### PR TITLE
feat: expand bitwise identities in SimplifyArithmeticPass

### DIFF
--- a/Vibe.Decompiler.Tests/Transformations/SimplifyArithmeticPassTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/SimplifyArithmeticPassTests.cs
@@ -56,4 +56,57 @@ public class SimplifyArithmeticPassTests
         var zero = Assert.IsType<IR.Const>(stmt.Rhs);
         Assert.Equal(0, zero.Value);
     }
+
+    [Fact]
+    public void SimplifiesAndWithItself()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        var reg = new IR.RegExpr("rax");
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rdx"),
+            new IR.BinOpExpr(IR.BinOp.And, reg, reg)));
+        fn.Blocks.Add(bb);
+
+        var pass = new SimplifyArithmeticPass();
+        pass.Run(fn);
+
+        var stmt = Assert.IsType<IR.AssignStmt>(fn.Blocks[0].Statements[0]);
+        var rhs = Assert.IsType<IR.RegExpr>(stmt.Rhs);
+        Assert.Equal("rax", rhs.Name);
+    }
+
+    [Fact]
+    public void SimplifiesOrWithItself()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        var reg = new IR.RegExpr("rax");
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rdx"),
+            new IR.BinOpExpr(IR.BinOp.Or, reg, reg)));
+        fn.Blocks.Add(bb);
+
+        var pass = new SimplifyArithmeticPass();
+        pass.Run(fn);
+
+        var stmt = Assert.IsType<IR.AssignStmt>(fn.Blocks[0].Statements[0]);
+        var rhs = Assert.IsType<IR.RegExpr>(stmt.Rhs);
+        Assert.Equal("rax", rhs.Name);
+    }
+
+    [Fact]
+    public void SimplifiesOrWithAllOnes()
+    {
+        var fn = new IR.FunctionIR("test");
+        var bb = new IR.BasicBlock(new IR.LabelSymbol("L0", 0));
+        bb.Statements.Add(new IR.AssignStmt(new IR.RegExpr("rdx"),
+            new IR.BinOpExpr(IR.BinOp.Or, new IR.RegExpr("rax"), new IR.Const(-1, 64))));
+        fn.Blocks.Add(bb);
+
+        var pass = new SimplifyArithmeticPass();
+        pass.Run(fn);
+
+        var stmt = Assert.IsType<IR.AssignStmt>(fn.Blocks[0].Statements[0]);
+        var allOnes = Assert.IsType<IR.Const>(stmt.Rhs);
+        Assert.Equal(-1, allOnes.Value);
+    }
 }

--- a/Vibe.Decompiler/Transformations/SimplifyArithmeticPass.cs
+++ b/Vibe.Decompiler/Transformations/SimplifyArithmeticPass.cs
@@ -45,10 +45,14 @@ public sealed class SimplifyArithmeticPass : IRRewriter, ITransformationPass
                 if (IsZero(L) || IsZero(R)) return MakeZeroFrom(L, R);
                 if (IsAllOnes(L)) return R;
                 if (IsAllOnes(R)) return L;
+                if (ExpressionsEqual(L, R)) return L;
                 break;
             case IR.BinOp.Or:
                 if (IsZero(L)) return R;
                 if (IsZero(R)) return L;
+                if (IsAllOnes(L)) return L;
+                if (IsAllOnes(R)) return R;
+                if (ExpressionsEqual(L, R)) return L;
                 break;
             case IR.BinOp.Xor:
                 if (IsZero(L)) return R;
@@ -78,6 +82,7 @@ public sealed class SimplifyArithmeticPass : IRRewriter, ITransformationPass
         }
         return false;
     }
+    // Uses record-based structural equality for IR expressions
     private static bool ExpressionsEqual(IR.Expr a, IR.Expr b) => a.Equals(b);
     private static IR.Expr MakeZeroFrom(IR.Expr a, IR.Expr b)
     {


### PR DESCRIPTION
## Summary
- handle `x & x`, `x | x`, and `x | ~0` identities in SimplifyArithmeticPass
- note reliance on record equality for expression comparison
- add unit tests for new bitwise simplifications

## Testing
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c20df827748320a4f979efce9d4dde