### PR TITLE
Add XML doc comments to tests

### DIFF
--- a/Vibe.Decompiler.Tests/Transformations/SimplifyArithmeticPassTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/SimplifyArithmeticPassTests.cs
@@ -3,8 +3,14 @@ using Xunit;
 
 namespace Vibe.Decompiler.Tests.Transformations;
 
+/// <summary>
+/// Verifies simplifications performed by <see cref="SimplifyArithmeticPass"/>.
+/// </summary>
 public class SimplifyArithmeticPassTests
 {
+    /// <summary>
+    /// Removes additions by zero from arithmetic expressions.
+    /// </summary>
     [Fact]
     public void SimplifiesAdditionWithZero()
     {
@@ -22,6 +28,9 @@ public class SimplifyArithmeticPassTests
         Assert.Equal("rax", rhs.Name);
     }
 
+    /// <summary>
+    /// Eliminates multiplications by one.
+    /// </summary>
     [Fact]
     public void SimplifiesMultiplicationByOne()
     {
@@ -39,6 +48,9 @@ public class SimplifyArithmeticPassTests
         Assert.Equal("rax", rhs.Name);
     }
 
+    /// <summary>
+    /// Simplifies an XOR of a register with itself to a constant zero.
+    /// </summary>
     [Fact]
     public void SimplifiesXorWithItselfToZero()
     {

--- a/Vibe.Decompiler.Tests/Transformations/SimplifyRedundantAssignPassTests.cs
+++ b/Vibe.Decompiler.Tests/Transformations/SimplifyRedundantAssignPassTests.cs
@@ -3,8 +3,14 @@ using Xunit;
 
 namespace Vibe.Decompiler.Tests.Transformations;
 
+/// <summary>
+/// Tests for the <see cref="SimplifyRedundantAssignPass"/> transformation.
+/// </summary>
 public class SimplifyRedundantAssignPassTests
 {
+    /// <summary>
+    /// Replaces assignments of a register to itself with a no-op statement.
+    /// </summary>
     [Fact]
     public void RemovesSelfAssignments()
     {

--- a/tests/Vibe.Decompiler.Tests/ConstantDatabaseTests.cs
+++ b/tests/Vibe.Decompiler.Tests/ConstantDatabaseTests.cs
@@ -14,8 +14,15 @@ public enum TestAccess
     Execute = 4
 }
 
+/// <summary>
+/// Tests functionality of <see cref="ConstantDatabase"/> for mapping and
+/// formatting constant values.
+/// </summary>
 public class ConstantDatabaseTests
 {
+    /// <summary>
+    /// Maps an argument enum value and retrieves its expected enum type.
+    /// </summary>
     [Fact]
     public void MapAndLookupArgEnum()
     {
@@ -27,6 +34,9 @@ public class ConstantDatabaseTests
         Assert.Equal(typeof(TestAccess).FullName, name);
     }
 
+    /// <summary>
+    /// Formats an unknown constant value as hexadecimal.
+    /// </summary>
     [Fact]
     public void UnknownValueFallsBackToHex()
     {
@@ -37,6 +47,9 @@ public class ConstantDatabaseTests
         Assert.Equal("0x80", formatted);
     }
 
+    /// <summary>
+    /// Formats combinations of flags as pipe-separated enum names.
+    /// </summary>
     [Property]
     public void FormatsFlagCombinationsCorrectly(TestAccess[] flags)
     {

--- a/tests/Vibe.Decompiler.Tests/PrettyPrinterTests.cs
+++ b/tests/Vibe.Decompiler.Tests/PrettyPrinterTests.cs
@@ -4,8 +4,14 @@ using static Vibe.Decompiler.IR.X;
 
 namespace Vibe.Decompiler.Tests;
 
+/// <summary>
+/// Tests the <see cref="IR.PrettyPrinter"/> for generating readable IR output.
+/// </summary>
 public class PrettyPrinterTests
 {
+    /// <summary>
+    /// Pretty-prints a simple function containing a local variable and return statement.
+    /// </summary>
     [Fact]
     public void PrintsSimpleFunction()
     {
@@ -33,6 +39,9 @@ public class PrettyPrinterTests
         Assert.Equal(expected, text);
     }
 
+    /// <summary>
+    /// Ensures binary expressions are parenthesized according to precedence rules.
+    /// </summary>
     [Fact]
     public void RespectsExpressionPrecedence()
     {

--- a/tests/Vibe.Decompiler.Tests/TestHelpers.cs
+++ b/tests/Vibe.Decompiler.Tests/TestHelpers.cs
@@ -1,7 +1,14 @@
 namespace Vibe.Decompiler.Tests;
 
+/// <summary>
+/// Provides helper extensions used by test code.
+/// </summary>
 internal static class TestHelpers
 {
+    /// <summary>
+    /// Replaces Windows line endings with Unix line endings to ensure
+    /// cross-platform string comparison in tests.
+    /// </summary>
     public static string NormalizeLineEndings(this string text) =>
         text.Replace("\r\n", "\n");
 }


### PR DESCRIPTION
## Summary
- document decompiler test classes and helper methods with XML comments
- clarify intent of constant database, pretty printer, and transformation tests

## Testing
- `dotnet test tests/Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c20f2067e8832082676a143789e942