### PR TITLE
Log all LLM interactions through logger

### DIFF
--- a/Vibe.Decompiler.Tests/OpenAiLlmProviderTests.cs
+++ b/Vibe.Decompiler.Tests/OpenAiLlmProviderTests.cs
@@ -8,12 +8,13 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Vibe.Decompiler.Models;
 using Xunit;
 
 namespace Vibe.Decompiler.Tests;
 
 /// <summary>
-/// Tests for the <see cref="OpenAiLlmProvider"/> to ensure HTTP requests are
+/// Tests for the <see cref="OpenAiModelProvider"/> to ensure HTTP requests are
 /// formed correctly and the JSON response is parsed as expected.
 /// </summary>
 public class OpenAiLlmProviderTests
@@ -56,20 +57,20 @@ public class OpenAiLlmProviderTests
     }
 
     /// <summary>
-    /// Ensures that <see cref="OpenAiLlmProvider.RefineAsync"/> targets the
+    /// Ensures that <see cref="OpenAiModelProvider.RefineAsync"/> targets the
     /// <c>/responses</c> endpoint and that the resulting text is extracted from
     /// the nested JSON structure.
     /// </summary>
     [Fact]
     public async Task RefineAsync_UsesResponsesEndpointAndParsesOutput()
     {
-        var jsonResponse = "{\"output\":[{\"content\":[{\"text\":\"result code\"}]}]}";
+        var jsonResponse = "{\"output\":[{\"type\":\"message\",\"content\":[{\"text\":\"result code\"}]}]}";
         var handler = new FakeHandler(jsonResponse);
         var client = new HttpClient(handler);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test");
 
-        using var provider = new OpenAiLlmProvider("test");
-        var field = typeof(OpenAiLlmProvider).GetField("_http", BindingFlags.NonPublic | BindingFlags.Instance);
+        using var provider = new OpenAiModelProvider("test");
+        var field = typeof(OpenAiModelProvider).GetField("_http", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(field);
         field!.SetValue(provider, client);
 

--- a/Vibe.Decompiler/Models/AnthropicModelProvider.cs
+++ b/Vibe.Decompiler/Models/AnthropicModelProvider.cs
@@ -2,6 +2,7 @@
 
 using System.Text;
 using System.Text.Json;
+using Vibe.Utils;
 
 namespace Vibe.Decompiler.Models;
 
@@ -56,6 +57,7 @@ public sealed class AnthropicModelProvider : IModelProvider
         };
 
         var json = JsonSerializer.Serialize(req);
+        Logger.Log($"Anthropic request: {json}");
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var resp = await _http.PostAsync("https://api.anthropic.com/v1/messages", content, cancellationToken);
 
@@ -74,7 +76,9 @@ public sealed class AnthropicModelProvider : IModelProvider
         if (message is null)
             throw new InvalidOperationException("Anthropic API response missing text");
 
-        return message.Trim();
+        message = message.Trim();
+        Logger.Log($"Anthropic response: {message}");
+        return message;
     }
 
     /// <inheritdoc />

--- a/Vibe.Decompiler/Models/OpenAiModelProvider.cs
+++ b/Vibe.Decompiler/Models/OpenAiModelProvider.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Vibe.Utils;
 
 namespace Vibe.Decompiler.Models;
 
@@ -66,6 +67,7 @@ public sealed class OpenAiModelProvider : IModelProvider
 
         var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
         var json = JsonSerializer.Serialize(req, options);
+        Logger.Log($"OpenAI request: {json}");
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var resp = await _http.PostAsync("https://api.openai.com/v1/responses", content, cancellationToken);
 
@@ -114,7 +116,9 @@ public sealed class OpenAiModelProvider : IModelProvider
         if (string.IsNullOrEmpty(message))
             throw new InvalidOperationException("OpenAI API response missing text");
 
-        return message.Trim();
+        message = message.Trim();
+        Logger.Log($"OpenAI response: {message}");
+        return message;
     }
 
     /// <inheritdoc />

--- a/Vibe.Decompiler/Web/DuckDuckGoDocFetcher.cs
+++ b/Vibe.Decompiler/Web/DuckDuckGoDocFetcher.cs
@@ -47,6 +47,7 @@ public sealed class OpenAiDocPageEvaluator : IDocPageEvaluator
 
         var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
         var json = JsonSerializer.Serialize(req, options);
+        Logger.Log($"OpenAI doc eval request: {json}");
         using var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
         using var resp = await _http.PostAsync("https://api.openai.com/v1/chat/completions", httpContent, cancellationToken);
 
@@ -65,7 +66,9 @@ public sealed class OpenAiDocPageEvaluator : IDocPageEvaluator
         if (message is null)
             return false;
 
-        return message.Trim().StartsWith("y", StringComparison.OrdinalIgnoreCase);
+        message = message.Trim();
+        Logger.Log($"OpenAI doc eval response: {message}");
+        return message.StartsWith("y", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- log OpenAI and Anthropic request/response payloads
- log doc-page evaluation prompts and answers
- adjust OpenAI provider tests for new structure

## Testing
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj` *(fails: Assert.Contains() Failure in PrettyPrinterTests.EmitsHeaderCommentByDefault)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a89785a88320bb97f78235269b64