### PR TITLE
Decompile managed methods to C#

### DIFF
--- a/Vibe.Decompiler/Vibe.Decompiler.csproj
+++ b/Vibe.Decompiler/Vibe.Decompiler.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Iced" Version="1.21.0" />
     <PackageReference Include="PeNet" Version="5.1.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/dll-information-display.md
+++ b/docs/dll-information-display.md
@@ -30,7 +30,7 @@ In addition to the shared fields, managed (.NET) assemblies can surface:
 - Custom attributes and security declarations
 - Embedded resources and manifest metadata
 - Debug information such as PDB path
-- Preview panes for IL and high-level decompiled code
+- Preview pane for decompiled C# code
 
 ## Unmanaged libraries
 


### PR DESCRIPTION
## Summary
- decompile managed methods with ILSpy's CSharpDecompiler
- reference ICSharpCode.Decompiler library
- update docs to mention C# output

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4aec5e9f48320b43b3d30791fa968