### PR TITLE
Send context to LLM when decompiling managed methods

### DIFF
--- a/Vibe.Cui/Program.cs
+++ b/Vibe.Cui/Program.cs
@@ -123,7 +123,7 @@ public class Program
                 {
                     var methodName = (string)args2.Value;
                     var method = type.Methods.First(m => m.FullName == methodName);
-                    var body = Analyzer.GetManagedMethodBody(method);
+                    var body = Analyzer.GetManagedMethodBody(Dll!, method);
                     CodeView.Text = body;
                     Application.RequestStop();
                 };

--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -644,7 +644,8 @@ public partial class MainWindow : Window
                 OutputBox.Text = $"Type: {td.FullName}";
                 return;
             case MethodDefinition md:
-                OutputBox.Text = _dllAnalyzer.GetManagedMethodBody(md);
+                if (GetRootItem(item).Tag is LoadedDll rootDll)
+                    OutputBox.Text = _dllAnalyzer.GetManagedMethodBody(rootDll, md);
                 return;
         }
     }


### PR DESCRIPTION
## Summary
- refine decompiled managed method code through the LLM using BuildLlmContext
- wire CLI and GUI callers to provide the loaded DLL for managed method refinement

## Testing
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj` *(fails: PrettyPrinterTests.EmitsHeaderCommentByDefault)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b62ac0988320b1ede9e6c04e03e7