### PR TITLE
Make GetManagedMethodBody async

### DIFF
--- a/Vibe.Cui/Program.cs
+++ b/Vibe.Cui/Program.cs
@@ -119,13 +119,17 @@ public class Program
                 var dlg = new Dialog("Select Method", 60, 20, close);
                 dlg.Add(methodList);
 
-                methodList.OpenSelectedItem += args2 =>
+                methodList.OpenSelectedItem += async args2 =>
                 {
                     var methodName = (string)args2.Value;
                     var method = type.Methods.First(m => m.FullName == methodName);
-                    var body = Analyzer.GetManagedMethodBody(Dll!, method);
-                    CodeView.Text = body;
-                    Application.RequestStop();
+                    CodeView.Text = "Loading...";
+                    var body = await Analyzer.GetManagedMethodBodyAsync(Dll!, method);
+                    Application.MainLoop.Invoke(() =>
+                    {
+                        CodeView.Text = body;
+                        Application.RequestStop();
+                    });
                 };
                 close.Clicked += () => Application.RequestStop();
 

--- a/Vibe.Decompiler.Tests/OpenAiLlmProviderTests.cs
+++ b/Vibe.Decompiler.Tests/OpenAiLlmProviderTests.cs
@@ -74,7 +74,7 @@ public class OpenAiLlmProviderTests
         Assert.NotNull(field);
         field!.SetValue(provider, client);
 
-        string refined = await provider.RefineAsync("int main() {}");
+        string refined = await provider.RefineAsync("int main() {}", "C");
         Assert.Equal("result code", refined);
 
         Assert.Equal("https://api.openai.com/v1/responses", handler.LastRequest!.RequestUri!.ToString());

--- a/Vibe.Decompiler/DllAnalyzer.cs
+++ b/Vibe.Decompiler/DllAnalyzer.cs
@@ -73,7 +73,7 @@ public sealed class DllAnalyzer : IDisposable
     /// <summary>
     /// Returns decompiled C# code for the specified managed method.
     /// </summary>
-    public string GetManagedMethodBody(LoadedDll dll, MethodDefinition method)
+    public async Task<string> GetManagedMethodBodyAsync(LoadedDll dll, MethodDefinition method)
     {
         if (!method.HasBody)
             return "// Method has no body";
@@ -94,7 +94,7 @@ public sealed class DllAnalyzer : IDisposable
             if (_provider != null)
             {
                 var context = BuildLlmContext(dll);
-                code = _provider.RefineAsync(context + code, "C#", null, CancellationToken.None).GetAwaiter().GetResult();
+                code = await _provider.RefineAsync(context + code, "C#", null, CancellationToken.None);
             }
 
             return code;

--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -645,7 +645,7 @@ public partial class MainWindow : Window
                 return;
             case MethodDefinition md:
                 if (GetRootItem(item).Tag is LoadedDll rootDll)
-                    OutputBox.Text = _dllAnalyzer.GetManagedMethodBody(rootDll, md);
+                    OutputBox.Text = await _dllAnalyzer.GetManagedMethodBodyAsync(rootDll, md);
                 return;
         }
     }


### PR DESCRIPTION
## Summary
- refactor DllAnalyzer.GetManagedMethodBody into async method that awaits the model provider
- update CLI and GUI to call GetManagedMethodBodyAsync and marshal results back to UI
- adjust OpenAI provider test for updated signature

## Testing
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj` *(fails: Assert.Contains() Failure: Sub-string not found)*
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*


------
https://chatgpt.com/codex/tasks/task_e_68c4c8bf94a88320873e656dedc714e6