### PR TITLE
feat(utils): reject open generic types

### DIFF
--- a/Vibe.Utils/TypeExtensions.cs
+++ b/Vibe.Utils/TypeExtensions.cs
@@ -24,6 +24,8 @@ public static class TypeExtensions
     public static dynamic ToDynamicObject(this Type staticType)
     {
         ArgumentNullException.ThrowIfNull(staticType);
+        if (staticType.ContainsGenericParameters)
+            throw new ArgumentException("Open generic types are not supported.", nameof(staticType));
         return new StaticTypeProxy(staticType);
     }
 

--- a/tests/Vibe.Tests/TypeExtensionsTests.cs
+++ b/tests/Vibe.Tests/TypeExtensionsTests.cs
@@ -200,9 +200,9 @@ public static class TypeExtensionsTests
     }
 
     /// <summary>
-    /// Passing an open generic type is currently unsupported and should throw a meaningful exception.
+    /// Passing an open generic type throws an <see cref="ArgumentException"/>.
     /// </summary>
-    [Fact(Skip = "ToDynamicObject should reject open generic types with a clear exception.")]
+    [Fact]
     public static void OpenGenericTypeRejected()
     {
         Type openType = typeof(GenericContainer<>);


### PR DESCRIPTION
## Summary
- avoid unexpected behavior by throwing on open generic types in `ToDynamicObject`
- test that open generic types are rejected

## Testing
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj --no-build --filter FullyQualifiedName~TypeExtensionsTests`


------
https://chatgpt.com/codex/tasks/task_e_68c4ca7641888320823e189ea78746ba