### PR TITLE
Bind log pane to message collection

### DIFF
--- a/Vibe.Gui/MainWindow.xaml
+++ b/Vibe.Gui/MainWindow.xaml
@@ -62,6 +62,7 @@
                  FontFamily="Consolas" SelectionMode="Extended"
                  KeyDown="ExceptionsList_OnKeyDown"/>
         <ListBox x:Key="LogControl" Margin="4"
+                 ItemsSource="{Binding}"
                  Background="{StaticResource PanelBrush}"
                  BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
                  Foreground="{StaticResource TextBrush}" FontFamily="Consolas"


### PR DESCRIPTION
## Summary
- bind the docked log pane's ListBox to the window logger messages

## Testing
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj` *(fails: Assert.Contains() Failure in PrettyPrinterTests.EmitsHeaderCommentByDefault)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cf3cb31c83209c692e1ba20e83f4