### PR TITLE
Show managed method pseudocode before LLM refinement

### DIFF
--- a/Vibe.Cui/Program.cs
+++ b/Vibe.Cui/Program.cs
@@ -124,7 +124,11 @@ public class Program
                     var methodName = (string)args2.Value;
                     var method = type.Methods.First(m => m.FullName == methodName);
                     CodeView.Text = "Loading...";
-                    var body = await Analyzer.GetManagedMethodBodyAsync(Dll!, method);
+                    var body = await Analyzer.GetManagedMethodBodyAsync(
+                        Dll!,
+                        method,
+                        new Progress<string>(p => Application.MainLoop.Invoke(() => CodeView.Text = p)),
+                        Dll.Cts.Token).ConfigureAwait(false);
                     Application.MainLoop.Invoke(() =>
                     {
                         CodeView.Text = body;


### PR DESCRIPTION
## Summary
- show raw C# decompilation immediately for managed methods and refine with LLM when ready
- add progress reporting and busy indicators for managed method selection in GUI
- update terminal UI to display preliminary managed method code while awaiting LLM

## Testing
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj`
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_e_68c4d14fbce48320b675435fe6083965