### PR TITLE
Fix Log view menu not showing log window

### DIFF
--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -268,10 +268,16 @@ public partial class MainWindow : Window
         var anchor = DockManager.Layout?.Descendents().OfType<LayoutAnchorable>().FirstOrDefault(a => a.ContentId == id);
         if (anchor == null)
             return;
-        if (anchor.IsHidden || anchor.IsAutoHidden)
+        if (anchor.IsHidden || anchor.IsAutoHidden || !anchor.IsVisible)
+        {
+            if (!anchor.IsVisible && !anchor.IsHidden)
+                anchor.Hide();
             anchor.Show();
+        }
         else
+        {
             anchor.Hide();
+        }
     }
 
     private void LoadDll(string path, bool showErrors)


### PR DESCRIPTION
## Summary
- ensure hidden log pane is made visible even when marked not visible
- hide then show log pane when previously invisible

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*


------
https://chatgpt.com/codex/tasks/task_e_68c4da17c30083208bbd9e6b6bc2914e