### PR TITLE
Replace placeholder Output panel with Log panel

### DIFF
--- a/Vibe.Gui/DefaultLayout.config
+++ b/Vibe.Gui/DefaultLayout.config
@@ -8,10 +8,9 @@
         <LayoutDocument Title="Decompiler View" ContentId="DecompilerView" CanClose="False" />
       </LayoutDocumentPane>
       <LayoutAnchorablePane DockHeight="200">
-        <LayoutAnchorable Title="Output" ContentId="Output" CanClose="False" />
+        <LayoutAnchorable Title="Log" ContentId="Log" CanClose="False" />
         <LayoutAnchorable Title="Search Results" ContentId="SearchResults" CanClose="False" />
         <LayoutAnchorable Title="Exceptions" ContentId="Exceptions" CanClose="False" IsVisible="False" />
-        <LayoutAnchorable Title="Log" ContentId="Log" CanClose="False" IsVisible="False" />
       </LayoutAnchorablePane>
     </LayoutPanel>
   </RootPanel>

--- a/Vibe.Gui/MainWindow.xaml
+++ b/Vibe.Gui/MainWindow.xaml
@@ -9,7 +9,7 @@
         PreviewKeyDown="Window_PreviewKeyDown" DragOver="Window_DragOver" Drop="Window_Drop">
     <Window.InputBindings>
         <KeyBinding Command="{x:Static local:MainWindow.ToggleExplorerCommand}" Gesture="Ctrl+Alt+E" />
-        <KeyBinding Command="{x:Static local:MainWindow.ToggleOutputCommand}" Gesture="Ctrl+Alt+O" />
+        <KeyBinding Command="{x:Static local:MainWindow.ToggleLogCommand}" Gesture="Ctrl+Alt+L" />
         <KeyBinding Command="{x:Static local:MainWindow.ToggleSearchCommand}" Gesture="Ctrl+Alt+S" />
         <KeyBinding Command="{x:Static local:MainWindow.ResetLayoutCommand}" Gesture="Ctrl+Alt+R" />
     </Window.InputBindings>
@@ -51,9 +51,6 @@
                 </TextBlock>
             </Border>
         </Grid>
-        <TextBox x:Key="OutputControl" Margin="4" Background="{StaticResource PanelBrush}"
-                 BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
-                 IsReadOnly="True" VerticalScrollBarVisibility="Auto" />
         <ListBox x:Key="SearchResultsControl" Margin="4" Background="{StaticResource PanelBrush}"
                  BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
         <ListBox x:Key="ExceptionsControl" Margin="4"
@@ -78,9 +75,8 @@
             </MenuItem>
             <MenuItem Header="_View">
                 <MenuItem Header="_Explorer" Command="{x:Static local:MainWindow.ToggleExplorerCommand}" />
-                <MenuItem Header="_Output" Command="{x:Static local:MainWindow.ToggleOutputCommand}" />
+                <MenuItem Header="_Log" Command="{x:Static local:MainWindow.ToggleLogCommand}" />
                 <MenuItem Header="_Search Results" Command="{x:Static local:MainWindow.ToggleSearchCommand}" />
-                <MenuItem Header="_Log" Click="Log_Click" />
                 <Separator />
                 <MenuItem Header="_Reset Window Layout" Command="{x:Static local:MainWindow.ResetLayoutCommand}" />
             </MenuItem>

--- a/docs/layout-system.md
+++ b/docs/layout-system.md
@@ -9,13 +9,13 @@ The `MainWindow` hosts a single `DockingManager`.  Tool windows are represented 
 Default tool windows:
 
 - **Explorer** – left side tree used for navigation.
-- **Output** – bottom log pane.
+- **Log** – bottom log pane.
 - **Search Results** – bottom placeholder for future search output.
 - **Decompiler View** – main document showing decompiled code.
 
 ## Default layout
 
-Explorer is docked left.  Decompiler View occupies the document area.  Output and Search Results share a tab group docked to the bottom.
+Explorer is docked left.  Decompiler View occupies the document area.  Log and Search Results share a tab group docked to the bottom.
 
 ## Layout serialization
 
@@ -28,7 +28,7 @@ Use **View ▸ Reset Window Layout** to discard the saved layout and return to t
 | Command | Shortcut | Description |
 | --- | --- | --- |
 | View ▸ Explorer | Ctrl+Alt+E | Toggle Explorer tool window |
-| View ▸ Output | Ctrl+Alt+O | Toggle Output window |
+| View ▸ Log | Ctrl+Alt+L | Toggle Log window |
 | View ▸ Search Results | Ctrl+Alt+S | Toggle Search Results window |
 | View ▸ Reset Window Layout | Ctrl+Alt+R | Restore default layout |
 


### PR DESCRIPTION
## Summary
- rename the Output tool window to Log and update associated command and menu
- drop unused Output control and add default Log pane to layout
- refresh layout documentation for new Log pane and shortcut

## Testing
- `dotnet test Vibe.Decompiler.Tests/Vibe.Decompiler.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c4dea4d1348320aee0d5fd566b19d6