### PR TITLE
Add Ctrl+O shortcut to open files

### DIFF
--- a/Vibe.Cui/Program.cs
+++ b/Vibe.Cui/Program.cs
@@ -29,7 +29,7 @@ public class Program
         {
             new MenuBarItem("_File", new MenuItem[]
             {
-                new MenuItem("_Open", string.Empty, OpenFile),
+                new MenuItem("_Open", "Ctrl+O", OpenFile, null, null, Key.CtrlMask | Key.O),
                 new MenuItem("_Quit", string.Empty, () => { Dll?.Dispose(); Application.RequestStop(); })
             }),
             new MenuBarItem("_View", new MenuItem[]

--- a/Vibe.Gui/MainWindow.xaml
+++ b/Vibe.Gui/MainWindow.xaml
@@ -12,6 +12,7 @@
         <KeyBinding Command="{x:Static local:MainWindow.ToggleLogCommand}" Gesture="Ctrl+Alt+L" />
         <KeyBinding Command="{x:Static local:MainWindow.ToggleSearchCommand}" Gesture="Ctrl+Alt+S" />
         <KeyBinding Command="{x:Static local:MainWindow.ResetLayoutCommand}" Gesture="Ctrl+Alt+R" />
+        <KeyBinding Command="{x:Static local:MainWindow.OpenDllCommand}" Gesture="Ctrl+O" />
     </Window.InputBindings>
     <Window.Resources>
         <Storyboard x:Key="StripeAnimation" RepeatBehavior="Forever">
@@ -68,7 +69,7 @@
     <DockPanel>
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="_File">
-                <MenuItem Header="_Open..." Click="OpenDll_Click" />
+                <MenuItem Header="_Open..." Click="OpenDll_Click" InputGestureText="Ctrl+O" />
                 <MenuItem Header="Recent _Files" x:Name="RecentFilesMenu" IsEnabled="False" />
                 <Separator />
                 <MenuItem Header="E_xit" Click="Exit_Click" />

--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -32,6 +32,7 @@ public partial class MainWindow : Window
     public static readonly RoutedUICommand ToggleLogCommand = new("Log", nameof(ToggleLogCommand), typeof(MainWindow), new InputGestureCollection { new KeyGesture(Key.L, ModifierKeys.Control | ModifierKeys.Alt) });
     public static readonly RoutedUICommand ToggleSearchCommand = new("Search Results", nameof(ToggleSearchCommand), typeof(MainWindow), new InputGestureCollection { new KeyGesture(Key.S, ModifierKeys.Control | ModifierKeys.Alt) });
     public static readonly RoutedUICommand ResetLayoutCommand = new("Reset Window Layout", nameof(ResetLayoutCommand), typeof(MainWindow), new InputGestureCollection { new KeyGesture(Key.R, ModifierKeys.Control | ModifierKeys.Alt) });
+    public static readonly RoutedUICommand OpenDllCommand = new("Open DLL", nameof(OpenDllCommand), typeof(MainWindow), new InputGestureCollection { new KeyGesture(Key.O, ModifierKeys.Control) });
 
     private readonly string _layoutFile;
     private readonly Grid _decompilerContent;
@@ -109,6 +110,7 @@ public partial class MainWindow : Window
         CommandBindings.Add(new CommandBinding(ToggleLogCommand, (_, _) => ToggleAnchorable("Log")));
         CommandBindings.Add(new CommandBinding(ToggleSearchCommand, (_, _) => ToggleAnchorable("SearchResults")));
         CommandBindings.Add(new CommandBinding(ResetLayoutCommand, (_, _) => ResetLayout()));
+        CommandBindings.Add(new CommandBinding(OpenDllCommand, OpenDll_Click));
 
         OutputBox.TextArea.TextView.LineTransformers.Add(new PseudoCodeColorizer());
 


### PR DESCRIPTION
## Summary
- Enable Ctrl+O in GUI to open the file dialog and show hint in File menu
- Bind Ctrl+O in console UI to trigger Open dialog

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c57fbac29c8320910e097d019a998e