### PR TITLE
Redesign log pane as read-only text window

### DIFF
--- a/Vibe.Gui/MainWindow.xaml
+++ b/Vibe.Gui/MainWindow.xaml
@@ -58,12 +58,23 @@
                  BorderThickness="1" Foreground="{StaticResource TextBrush}"
                  FontFamily="Consolas" SelectionMode="Extended"
                  KeyDown="ExceptionsList_OnKeyDown"/>
-        <ListBox x:Key="LogControl" Margin="4"
-                 ItemsSource="{Binding}"
+        <TextBox x:Key="LogControl" Margin="4"
                  Background="{StaticResource PanelBrush}"
                  BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
                  Foreground="{StaticResource TextBrush}" FontFamily="Consolas"
-                 SelectionMode="Extended" />
+                 IsReadOnly="True" IsReadOnlyCaretVisible="True"
+                 TextWrapping="NoWrap"
+                 HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+            <TextBox.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Command="ApplicationCommands.Copy"/>
+                    <MenuItem Command="ApplicationCommands.SelectAll"/>
+                    <Separator/>
+                    <MenuItem Header="Word Wrap" IsCheckable="True"
+                              Click="LogWordWrap_Click"/>
+                </ContextMenu>
+            </TextBox.ContextMenu>
+        </TextBox>
     </Window.Resources>
     <DockPanel>
         <Menu DockPanel.Dock="Top">


### PR DESCRIPTION
## Summary
- Switch log pane from ListBox to read-only TextBox with copy/select context menu and optional word wrap
- Append log messages directly to the TextBox and add word wrap toggle handler

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c583a28a0c8320a91a04e2f974d1e9