### PR TITLE
Add multi-tab decompiler view

### DIFF
--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
 using System.Windows.Threading;
 using System.Windows.Input;
+using System.Windows.Markup;
 using AvalonDock.Layout;
 using AvalonDock.Layout.Serialization;
 using Microsoft.Win32;
@@ -682,6 +683,15 @@ public partial class MainWindow : Window
         if (DllTree.SelectedItem is not TreeViewItem item)
             return;
 
+        if ((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+        {
+            if (item.Tag is ExportItem or MethodDefinition)
+            {
+                await OpenItemInNewTabAsync(item);
+                return;
+            }
+        }
+
         switch (item.Tag)
         {
             case LoadedDll dll:
@@ -772,6 +782,98 @@ public partial class MainWindow : Window
                     }
                 }
                 return;
+        }
+    }
+
+    private Grid CloneDecompilerContent(out TextEditor editor)
+    {
+        var template = (Grid)FindResource("DecompilerContent");
+        var clone = (Grid)XamlReader.Parse(XamlWriter.Save(template));
+        editor = (TextEditor)clone.Children[0];
+        editor.TextArea.TextView.LineTransformers.Add(new PseudoCodeColorizer());
+        return clone;
+    }
+
+    private async Task OpenItemInNewTabAsync(TreeViewItem item)
+    {
+        var pane = DockManager.Layout?.Descendents().OfType<LayoutDocumentPane>().FirstOrDefault();
+        if (pane == null)
+            return;
+
+        var content = CloneDecompilerContent(out var editor);
+        string title = item.Header is FrameworkElement fe && fe is StackPanel sp && sp.Children.OfType<Border>().FirstOrDefault()?.Child is TextBlock tb ? tb.Text : "View";
+        var doc = new LayoutDocument { Title = title, Content = content };
+        pane.Children.Add(doc);
+        doc.IsActive = true;
+
+        switch (item.Tag)
+        {
+            case ExportItem exp:
+                editor.Text = string.Empty;
+                BusyBar.Visibility = Visibility.Visible;
+                var dllItem = exp.Dll;
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(dllItem.Cts.Token))
+                {
+                    var token = cts.Token;
+                    try
+                    {
+                        var progress = new Progress<string>(t => editor.Text = t);
+                        var output = await _dllAnalyzer.GetDecompiledExportAsync(dllItem, exp.Name, progress, token);
+                        editor.Text = output;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        if (!token.IsCancellationRequested)
+                        {
+                            editor.Text = $"Operation canceled: {ex.Message}";
+                            ExceptionManager.Handle(ex);
+                        }
+                        else
+                        {
+                            Logger.LogException(ex);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        editor.Text = $"Error: {ex.Message}";
+                        ExceptionManager.Handle(ex);
+                    }
+                }
+                BusyBar.Visibility = Visibility.Collapsed;
+                break;
+            case MethodDefinition md:
+                editor.Text = string.Empty;
+                BusyBar.Visibility = Visibility.Visible;
+                if (GetRootItem(item).Tag is LoadedDll rootDll)
+                {
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(rootDll.Cts.Token);
+                    var token = cts.Token;
+                    try
+                    {
+                        var progress = new Progress<string>(t => editor.Text = t);
+                        var body = await _dllAnalyzer.GetManagedMethodBodyAsync(rootDll, md, progress, token);
+                        editor.Text = body;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        if (!token.IsCancellationRequested)
+                        {
+                            editor.Text = $"Operation canceled: {ex.Message}";
+                            ExceptionManager.Handle(ex);
+                        }
+                        else
+                        {
+                            Logger.LogException(ex);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        editor.Text = $"Error: {ex.Message}";
+                        ExceptionManager.Handle(ex);
+                    }
+                }
+                BusyBar.Visibility = Visibility.Collapsed;
+                break;
         }
     }
 


### PR DESCRIPTION
## Summary
- Support opening decompilations in new tabs via Ctrl+Click in the tree view.
- Clone the decompiler view template and load results into independent document tabs.

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on Linux)*
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68c5842beba08320bfad6e4f8459c778