### PR TITLE
Remove overlay label from main window

### DIFF
--- a/Vibe.Gui/MainWindow.xaml
+++ b/Vibe.Gui/MainWindow.xaml
@@ -105,13 +105,6 @@
                         </LinearGradientBrush.RelativeTransform>
                     </LinearGradientBrush>
                 </Border.Background>
-                <TextBlock Text="Refining with AI" HorizontalAlignment="Center" VerticalAlignment="Center"
-                           Foreground="#80808080" FontSize="48" FontWeight="Bold" FontFamily="Arial Black"
-                           AutomationProperties.LiveSetting="Polite">
-                    <TextBlock.Effect>
-                        <DropShadowEffect BlurRadius="2" ShadowDepth="0" />
-                    </TextBlock.Effect>
-                </TextBlock>
             </Border>
         </Grid>
         <ListBox x:Key="SearchResultsControl" Margin="4" Background="{StaticResource PanelBrush}"


### PR DESCRIPTION
## Summary
- remove the `Refining with AI` label from the rewrite overlay, keeping the blur effect

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c592a7f89483209f6d469998987b9f