### PR TITLE
Add selectable syntax highlighting modes

### DIFF
--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -122,7 +122,7 @@ public partial class MainWindow : Window
         CommandBindings.Add(new CommandBinding(ResetLayoutCommand, (_, _) => ResetLayout()));
         CommandBindings.Add(new CommandBinding(OpenDllCommand, OpenDll_Click));
 
-        OutputBox.TextArea.TextView.LineTransformers.Add(new PseudoCodeColorizer());
+        OutputBox.SetSyntaxHighlighting(SyntaxHighlightingMode.Plain);
 
         var appData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Vibe");
         Directory.CreateDirectory(appData);
@@ -778,11 +778,13 @@ public partial class MainWindow : Window
         switch (item.Tag)
         {
             case LoadedDll dll:
+                OutputBox.SetSyntaxHighlighting(SyntaxHighlightingMode.Plain);
                 OutputBox.Text = _dllAnalyzer.GetSummary(dll);
                 if (mainDoc != null)
                     mainDoc.Title = "Decompiler View";
                 return;
             case ExportItem exp:
+                OutputBox.SetSyntaxHighlighting(SyntaxHighlightingMode.Cpp);
                 OutputBox.Text = string.Empty;
                 BusyBar.Visibility = Visibility.Visible;
                 var dllItem = exp.Dll;
@@ -825,11 +827,13 @@ public partial class MainWindow : Window
                 }
                 break;
             case TypeDefinition td:
+                OutputBox.SetSyntaxHighlighting(SyntaxHighlightingMode.Plain);
                 OutputBox.Text = $"Type: {td.FullName}";
                 if (mainDoc != null)
                     mainDoc.Title = "Decompiler View";
                 return;
             case MethodDefinition md:
+                OutputBox.SetSyntaxHighlighting(SyntaxHighlightingMode.CSharp);
                 OutputBox.Text = string.Empty;
                 BusyBar.Visibility = Visibility.Visible;
                 if (GetRootItem(item).Tag is LoadedDll rootDll)
@@ -881,7 +885,7 @@ public partial class MainWindow : Window
         var template = (Grid)FindResource("DecompilerContent");
         var clone = (Grid)XamlReader.Parse(XamlWriter.Save(template));
         editor = (TextEditor)clone.Children[0];
-        editor.TextArea.TextView.LineTransformers.Add(new PseudoCodeColorizer());
+        editor.SetSyntaxHighlighting(SyntaxHighlightingMode.Plain);
         return clone;
     }
 
@@ -900,6 +904,7 @@ public partial class MainWindow : Window
         switch (item.Tag)
         {
             case ExportItem exp:
+                editor.SetSyntaxHighlighting(SyntaxHighlightingMode.Cpp);
                 editor.Text = string.Empty;
                 BusyBar.Visibility = Visibility.Visible;
                 var dllItem = exp.Dll;
@@ -933,6 +938,7 @@ public partial class MainWindow : Window
                 BusyBar.Visibility = Visibility.Collapsed;
                 break;
             case MethodDefinition md:
+                editor.SetSyntaxHighlighting(SyntaxHighlightingMode.CSharp);
                 editor.Text = string.Empty;
                 BusyBar.Visibility = Visibility.Visible;
                 if (GetRootItem(item).Tag is LoadedDll rootDll)

--- a/Vibe.Gui/TextEditorExtensions.cs
+++ b/Vibe.Gui/TextEditorExtensions.cs
@@ -1,0 +1,58 @@
+using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Highlighting;
+using ICSharpCode.AvalonEdit.Rendering;
+
+namespace Vibe.Gui;
+
+/// <summary>
+/// Modes of syntax highlighting supported by the application.
+/// </summary>
+internal enum SyntaxHighlightingMode
+{
+    /// <summary>No syntax highlighting.</summary>
+    Plain,
+    /// <summary>Highlighting for C or C++ code.</summary>
+    Cpp,
+    /// <summary>Highlighting for C# code.</summary>
+    CSharp,
+}
+
+/// <summary>
+/// Extension helpers for configuring <see cref="TextEditor"/> instances.
+/// </summary>
+internal static class TextEditorExtensions
+{
+    private static readonly IHighlightingDefinition? CSharpDefinition =
+        HighlightingManager.Instance.GetDefinition("C#");
+
+    /// <summary>
+    /// Applies the requested syntax highlighting mode to the editor, removing any
+    /// previously applied <see cref="PseudoCodeColorizer"/>.
+    /// </summary>
+    public static void SetSyntaxHighlighting(this TextEditor editor, SyntaxHighlightingMode mode)
+    {
+        var transformers = editor.TextArea.TextView.LineTransformers;
+        for (int i = transformers.Count - 1; i >= 0; i--)
+        {
+            if (transformers[i] is PseudoCodeColorizer)
+                transformers.RemoveAt(i);
+        }
+
+        editor.SyntaxHighlighting = null;
+
+        switch (mode)
+        {
+            case SyntaxHighlightingMode.Cpp:
+                transformers.Add(new PseudoCodeColorizer());
+                break;
+            case SyntaxHighlightingMode.CSharp:
+                if (CSharpDefinition != null)
+                    editor.SyntaxHighlighting = CSharpDefinition;
+                break;
+            case SyntaxHighlightingMode.Plain:
+            default:
+                break;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add extension to choose AvalonEdit syntax mode (plain, C++ and C#)
- apply correct highlighting when showing DLL summaries, exports or managed methods

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" )*
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c59147d9608320a70eb30f67df5aa6