### PR TITLE
Support concurrent background decompilation tabs

### DIFF
--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -616,13 +616,13 @@ public partial class MainWindow : Window
 
     private void BeginRequest()
     {
-        _pendingRequests++;
+        Interlocked.Increment(ref _pendingRequests);
         BusyBar.Visibility = Visibility.Visible;
     }
 
     private void EndRequest()
     {
-        if (_pendingRequests > 0 && --_pendingRequests == 0)
+        if (Interlocked.Decrement(ref _pendingRequests) == 0)
             BusyBar.Visibility = Visibility.Collapsed;
     }
 


### PR DESCRIPTION
## Summary
- keep a count of pending decompiler requests and show BusyBar while any are active
- allow Ctrl+Click to open a tab in the background without cancelling the current LLM request
- enable background tabs to run their own decompilation via a new activate flag

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on Linux)*
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c5925ec134832084e2cef148340bfc