### PR TITLE
Prefix decompiled output with version comment

### DIFF
--- a/Vibe.Cui/Program.cs
+++ b/Vibe.Cui/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -155,9 +156,9 @@ public class Program
                 var code = await Analyzer.GetDecompiledExportAsync(
                     export.Dll,
                     export.Name,
-                    new Progress<string>(p => Application.MainLoop.Invoke(() => CodeView.Text = p)),
+                    new Progress<string>(p => Application.MainLoop.Invoke(() => CodeView.Text = PrependVersionComment(p, false))),
                     export.Dll.Cts.Token).ConfigureAwait(false);
-                Application.MainLoop.Invoke(() => CodeView.Text = code);
+                Application.MainLoop.Invoke(() => CodeView.Text = PrependVersionComment(code, true));
                 break;
             case MethodDefinition method:
                 if (method.Module?.FileName == null || !ModuleToDll.TryGetValue(method.Module.FileName, out var mdll))
@@ -169,9 +170,9 @@ public class Program
                 var body = await Analyzer.GetManagedMethodBodyAsync(
                     mdll,
                     method,
-                    new Progress<string>(p => Application.MainLoop.Invoke(() => CodeView.Text = p)),
+                    new Progress<string>(p => Application.MainLoop.Invoke(() => CodeView.Text = PrependVersionComment(p, false))),
                     mdll.Cts.Token).ConfigureAwait(false);
-                Application.MainLoop.Invoke(() => CodeView.Text = body);
+                Application.MainLoop.Invoke(() => CodeView.Text = PrependVersionComment(body, true));
                 break;
         }
     }
@@ -243,6 +244,11 @@ public class Program
             _ => type.Name
         };
     }
+
+    static string PrependVersionComment(string code, bool isFinal)
+        => string.IsNullOrEmpty(code)
+            ? code
+            : $"// {(isFinal ? "Final" : "Preliminary")} version{Environment.NewLine}{code}";
 
     sealed class NamespaceNode
     {

--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -794,12 +794,12 @@ public partial class MainWindow : Window
                 {
                     var progress = new Progress<string>(t =>
                     {
-                        OutputBox.Text = t;
+                        OutputBox.Text = PrependVersionComment(t, false);
                         if (_dllAnalyzer.HasLlmProvider)
                             ShowLlmOverlay();
                     });
                     var output = await _dllAnalyzer.GetDecompiledExportAsync(dllItem, exp.Name, progress, token);
-                    OutputBox.Text = output;
+                    OutputBox.Text = PrependVersionComment(output, true);
                 }
                 catch (OperationCanceledException ex)
                 {
@@ -842,12 +842,12 @@ public partial class MainWindow : Window
                     {
                         var progress = new Progress<string>(t =>
                         {
-                            OutputBox.Text = t;
+                            OutputBox.Text = PrependVersionComment(t, false);
                             if (_dllAnalyzer.HasLlmProvider)
                                 ShowLlmOverlay();
                         });
                         var body = await _dllAnalyzer.GetManagedMethodBodyAsync(rootDll, md, progress, mtoken);
-                        OutputBox.Text = body;
+                        OutputBox.Text = PrependVersionComment(body, true);
                     }
                     catch (OperationCanceledException ex)
                     {
@@ -910,9 +910,9 @@ public partial class MainWindow : Window
                     var token = cts.Token;
                     try
                     {
-                        var progress = new Progress<string>(t => editor.Text = t);
+                        var progress = new Progress<string>(t => editor.Text = PrependVersionComment(t, false));
                         var output = await _dllAnalyzer.GetDecompiledExportAsync(dllItem, exp.Name, progress, token);
-                        editor.Text = output;
+                        editor.Text = PrependVersionComment(output, true);
                     }
                     catch (OperationCanceledException ex)
                     {
@@ -943,9 +943,9 @@ public partial class MainWindow : Window
                     var token = cts.Token;
                     try
                     {
-                        var progress = new Progress<string>(t => editor.Text = t);
+                        var progress = new Progress<string>(t => editor.Text = PrependVersionComment(t, false));
                         var body = await _dllAnalyzer.GetManagedMethodBodyAsync(rootDll, md, progress, token);
-                        editor.Text = body;
+                        editor.Text = PrependVersionComment(body, true);
                     }
                     catch (OperationCanceledException ex)
                     {
@@ -1080,4 +1080,9 @@ public partial class MainWindow : Window
         var dlg = new AboutWindow { Owner = this };
         dlg.ShowDialog();
     }
+
+    private static string PrependVersionComment(string code, bool isFinal)
+        => string.IsNullOrEmpty(code)
+            ? code
+            : $"// {(isFinal ? "Final" : "Preliminary")} version{Environment.NewLine}{code}";
 }


### PR DESCRIPTION
## Summary
- mark GUI decompilation previews as preliminary and final code with comment banner
- annotate CLI decompiled output with preliminary/final comment

## Testing
- `dotnet test Vibe.Decompiler.Tests`
- `dotnet test tests/Vibe.Tests --no-build`
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop"; directory did not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c5953d32f08320a92140b4aae67973