### PR TITLE
fix: prevent double decrement of pending request counter

### DIFF
--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -838,9 +838,8 @@ public partial class MainWindow : Window
                 finally
                 {
                     if (_currentRequestCts?.Token == token)
-                        CancelCurrentRequest();
-                    else
-                        EndRequest();
+                        CancelCurrentRequest(); // matched token -> cancel and decrement
+                    // mismatched token already accounted for via CancelCurrentRequest()
                 }
                 break;
             case TypeDefinition td:
@@ -888,9 +887,8 @@ public partial class MainWindow : Window
                     finally
                     {
                         if (_currentRequestCts?.Token == mtoken)
-                            CancelCurrentRequest();
-                        else
-                            EndRequest();
+                            CancelCurrentRequest(); // matched token -> cancel and decrement
+                        // mismatched token already accounted for via CancelCurrentRequest()
                     }
                 }
                 else


### PR DESCRIPTION
## Summary
- avoid double decrement when a decompilation request is superseded, keeping BusyBar visible while replacements run

## Testing
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c59922fd48832096f0012ceec3273a