### PR TITLE
Support concurrent background decompilation tabs

### DIFF
--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -635,7 +635,6 @@ public partial class MainWindow : Window
         _currentRequestCts.Dispose();
         _currentRequestCts = null;
 
-        EndRequest();
         HideLlmOverlay();
     }
 
@@ -838,9 +837,12 @@ public partial class MainWindow : Window
                 finally
                 {
                     if (_currentRequestCts?.Token == token)
-                        CancelCurrentRequest();
-                    else
-                        EndRequest();
+                    {
+                        _currentRequestCts.Dispose();
+                        _currentRequestCts = null;
+                        HideLlmOverlay();
+                    }
+                    EndRequest();
                 }
                 break;
             case TypeDefinition td:
@@ -888,9 +890,12 @@ public partial class MainWindow : Window
                     finally
                     {
                         if (_currentRequestCts?.Token == mtoken)
-                            CancelCurrentRequest();
-                        else
-                            EndRequest();
+                        {
+                            _currentRequestCts.Dispose();
+                            _currentRequestCts = null;
+                            HideLlmOverlay();
+                        }
+                        EndRequest();
                     }
                 }
                 else


### PR DESCRIPTION
## Summary
- remove immediate request count decrement on cancellation
- clean up CTS only after matching request completes to prevent BusyBar flicker

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on Linux)*
- `dotnet test tests/Vibe.Tests/Vibe.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c59933e76c8320bded652e50e302e8