### PR TITLE
refactor: extract version comment helper

### DIFF
--- a/Vibe.Cui/Program.cs
+++ b/Vibe.Cui/Program.cs
@@ -6,6 +6,7 @@ using Mono.Cecil;
 using Terminal.Gui;
 using Terminal.Gui.Trees;
 using Vibe.Decompiler;
+using static Vibe.Utils.CodeUtils;
 
 /// <summary>
 /// Entry point and console user interface for exploring DLL exports and
@@ -244,11 +245,6 @@ public class Program
             _ => type.Name
         };
     }
-
-    static string PrependVersionComment(string code, bool isFinal)
-        => string.IsNullOrEmpty(code)
-            ? code
-            : $"// {(isFinal ? "Final" : "Preliminary")} version{Environment.NewLine}{code}";
 
     sealed class NamespaceNode
     {

--- a/Vibe.Cui/Vibe.Cui.csproj
+++ b/Vibe.Cui/Vibe.Cui.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Vibe.Decompiler\Vibe.Decompiler.csproj" />
+    <ProjectReference Include="..\Vibe.Utils\Vibe.Utils.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />

--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ using Mono.Cecil;
 using Vibe.Decompiler;
 using Vibe.Decompiler.Models;
 using Vibe.Utils;
+using static Vibe.Utils.CodeUtils;
 
 namespace Vibe.Gui;
 
@@ -1081,8 +1082,4 @@ public partial class MainWindow : Window
         dlg.ShowDialog();
     }
 
-    private static string PrependVersionComment(string code, bool isFinal)
-        => string.IsNullOrEmpty(code)
-            ? code
-            : $"// {(isFinal ? "Final" : "Preliminary")} version{Environment.NewLine}{code}";
 }

--- a/Vibe.Utils/CodeUtils.cs
+++ b/Vibe.Utils/CodeUtils.cs
@@ -1,0 +1,20 @@
+using System;
+namespace Vibe.Utils;
+
+/// <summary>
+/// Helper methods for manipulating decompiled code strings.
+/// </summary>
+public static class CodeUtils
+{
+    /// <summary>
+    /// Prefixes the provided code with a comment indicating whether it
+    /// represents a preliminary or final version of the decompilation.
+    /// </summary>
+    /// <param name="code">The code to annotate.</param>
+    /// <param name="isFinal">True if the code is the final decompiled output; otherwise false.</param>
+    /// <returns>The annotated code string.</returns>
+    public static string PrependVersionComment(string code, bool isFinal) =>
+        string.IsNullOrEmpty(code)
+            ? code
+            : $"// {(isFinal ? "Final" : "Preliminary")} version{Environment.NewLine}{code}";
+}


### PR DESCRIPTION
## Summary
- centralize `PrependVersionComment` in `Vibe.Utils`
- reuse helper in CLI and GUI to remove duplication
- reference `Vibe.Utils` from console project

## Testing
- `dotnet test Vibe.Decompiler.Tests`
- `dotnet test tests/Vibe.Tests`
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop"; directory did not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c599ce0d7c8320ac727d3bbd09424c