### PR TITLE
Fix TreeView selection highlight style

### DIFF
--- a/Vibe.Gui/MainWindow.xaml
+++ b/Vibe.Gui/MainWindow.xaml
@@ -41,7 +41,7 @@
                   Background="{StaticResource PanelBrush}" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
                   SelectedItemChanged="DllTree_SelectedItemChanged" KeyDown="DllTree_KeyDown"
                   VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Recycling">
-            <TreeView.ItemContainerStyle>
+            <TreeView.Resources>
                 <Style TargetType="TreeViewItem">
                     <Setter Property="Template">
                         <Setter.Value>
@@ -84,7 +84,7 @@
                         </Setter.Value>
                     </Setter>
                 </Style>
-            </TreeView.ItemContainerStyle>
+            </TreeView.Resources>
         </TreeView>
         <Grid x:Key="DecompilerContent" Margin="4">
             <avalonEdit:TextEditor x:Name="OutputBox" FontFamily="Consolas" IsReadOnly="True" ShowLineNumbers="True"


### PR DESCRIPTION
## Summary
- Move TreeViewItem dotted border template into Explorer TreeView resources so it applies to manually created items

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68c59b5c204c8320b287075a67c3abb8