### PR TITLE
Restrict Unload context menu to DLL nodes

### DIFF
--- a/Vibe.Gui/MainWindow.xaml.cs
+++ b/Vibe.Gui/MainWindow.xaml.cs
@@ -1144,8 +1144,12 @@ public partial class MainWindow : Window
 
         if (root.Tag is LoadedDll or InvalidDll)
         {
-            menu.Items.Add(new MenuItem { Header = "Unload", Click = Unload_Click });
-            menu.Items.Add(new Separator());
+            if (item.Tag is LoadedDll or InvalidDll)
+            {
+                menu.Items.Add(new MenuItem { Header = "Unload", Click = Unload_Click });
+                menu.Items.Add(new Separator());
+            }
+
             menu.Items.Add(new MenuItem { Header = "Open Path", Click = OpenPath_Click, IsEnabled = path != null });
             menu.Items.Add(new MenuItem { Header = "Copy Path", Click = CopyPath_Click, IsEnabled = path != null });
             menu.Items.Add(new MenuItem { Header = "Properties", Click = Properties_Click, IsEnabled = path != null });


### PR DESCRIPTION
## Summary
- show Unload option only when selecting DLL root nodes in the tree view

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_e_68c5a8dc0ac48320a1c0313abe1e2cc5